### PR TITLE
fix task init command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ pip install clearml
 Add two lines to your code:
 ```python
 from clearml import Task
-task = Task(project_name='examples', task_name='hello world')
+task = Task.init(project_name='examples', task_name='hello world')
 ```
 
 You are done, everything your process outputs is now automagically logged into ClearML.


### PR DESCRIPTION
Change `task = Task(project_name='examples', task_name='hello world')` to `task = Task.init(project_name='examples', task_name='hello world')` to get rid of the following error:
```
clearml.errors.UsageError: Task object cannot be instantiated externally, use Task.current_task() or Task.get_task(...)
```

