### PR TITLE
fix strip remote diff

### DIFF
--- a/clearml/backend_interface/task/repo/detectors.py
+++ b/clearml/backend_interface/task/repo/detectors.py
@@ -139,7 +139,7 @@ class Detector(object):
                 **{
                     name[:-len(self._remote)]: self._get_command_output(
                         path, name[:-len(self._remote)], command + [info.branch],
-                        commands=commands, strip=name.startswith('diff'))
+                        commands=commands, strip=not name.startswith('diff'))
                     for name, command in attr.asdict(commands).items()
                     if command and (
                             name.endswith(self._remote) and


### PR DESCRIPTION
the results from git commands should be stripped only if they are **Not** diff (in the remote case it includes diff_remote and diff_remote_fallback)
see https://github.com/allegroai/clearml/issues/294 