### PR TITLE
fixed remove_files from Dataset class that did not match when files are in the root of the dataset

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -214,7 +214,7 @@ class Dataset(object):
 
             self._dataset_file_entries = {
                 k: v for k, v in self._dataset_file_entries.items()
-                if not (fnmatch(k, path) and fnmatch(k, '*/' + wildcard))}
+                if not (fnmatch(k, path) and fnmatch(k if '/' in k else '/{}'.format(k), '*/' + wildcard))}
 
         if verbose and org_files:
             for f in org_files:


### PR DESCRIPTION
Using the following script:
```from clearml import Dataset
dataset = Dataset.create(dataset_project='test', dataset_name='example')
dataset.add_files('/home/tglema/example.jpeg')
dataset.add_files('/home/tglema/logo.png')
print(dataset.list_files())
dataset.upload()
dataset.finalize()
dataset_new = Dataset.create(dataset_project='test', dataset_name='example_without_logo', parent_datasets=[dataset.id] )
print(dataset_new.list_files())
print(dataset_new.remove_files('logo.png'))
print(dataset_new.list_removed_files())
dataset_new.upload()
dataset_new.finalize()
```
I get this output:

> ['example.jpeg', 'logo.png']
Uploading compressed dataset changes (2 files, total 49.07 KB) to http://mvd0000xlrndtl2:8081
Upload completed (49.07 KB)
2021-02-05 17:04:38,333 - clearml.Task - INFO - Waiting to finish uploads
2021-02-05 17:04:38,334 - clearml.Task - INFO - Finished uploading
['example.jpeg', 'logo.png']
0
2021-02-05 17:04:41,339 - clearml - INFO - No pending files, skipping upload.
2021-02-05 17:04:41,935 - clearml.Task - INFO - Waiting to finish uploads
2021-02-05 17:04:41,935 - clearml.Task - INFO - Finished uploading

The "0" means that there is no file marked for removal, because the file `logo.png` is not being matched.