### PR TITLE
Added loading bar to SHA2 generation

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -983,7 +983,12 @@ class Dataset(object):
                 for f in files if f.is_file()]
             self._task.get_logger().report_text('Generating SHA2 hash for {} files'.format(len(file_entries)))
             pool = ThreadPool(cpu_count() * 2)
-            pool.map(self._calc_file_hash, file_entries)
+            try:
+                import tqdm
+                for _ in tqdm.tqdm(pool.imap_unordered(self._calc_file_hash, file_entries), total=len(file_entries)):
+                    pass
+            except ImportError:
+                pool.map(self._calc_file_hash, file_entries)
             pool.close()
             self._task.get_logger().report_text('Hash generation completed')
 


### PR DESCRIPTION
Currently, since there are no outputs during the SHA2 generation phase, on big datasets this leads to misunderstanding that system is unresponsive.

Also, since server usually has a timeout of 2 hours before aborting unresponsive experiments, SHA2 generation phase can get aborted on server due to unresponsiveness.

This modification aims to seek both potential misunderstanding by users and server killing the task due to unresponsiveness by adding a loading bar with estimated time to finish.