### PR TITLE
Fix encoding while saving notebook preview

### DIFF
--- a/clearml/backend_interface/task/repo/scriptinfo.py
+++ b/clearml/backend_interface/task/repo/scriptinfo.py
@@ -409,7 +409,7 @@ class _JupyterObserver(object):
                             from nbconvert.exporters import HTMLExporter  # noqa
                             html, _ = HTMLExporter().from_filename(filename=local_jupyter_filename)
                             local_html = Path(gettempdir()) / 'notebook_{}.html'.format(task.id)
-                            with open(local_html.as_posix(), 'wt') as f:
+                            with open(local_html.as_posix(), 'wt', encoding="utf-8") as f:
                                 f.write(html)
                             task.upload_artifact(
                                 name='notebook preview', artifact_object=local_html,


### PR DESCRIPTION
Fixes #442 

Explicitly sets to the default UTF-8 encoding while saving a jupyter notebook preview(from HTMLExporter).