### PR TITLE
Fix xgb train overloading

### DIFF
--- a/clearml/binding/frameworks/xgboost_bind.py
+++ b/clearml/binding/frameworks/xgboost_bind.py
@@ -116,13 +116,13 @@ class PatchXGBoostModelIO(PatchBaseModelIO):
         return model
 
     @staticmethod
-    def _train(original_fn, __obj, *args, **kwargs):
+    def _train(original_fn, *args, **kwargs):
         if PatchXGBoostModelIO.__callback_cls:
             callbacks = kwargs.get('callbacks') or []
             kwargs['callbacks'] = callbacks + [
                 PatchXGBoostModelIO.__callback_cls(task=PatchXGBoostModelIO.__main_task)
             ]
-        return original_fn(__obj, *args, **kwargs)
+        return original_fn(*args, **kwargs)
 
     @classmethod
     def _generate_training_callback_class(cls):


### PR DESCRIPTION
Per discussion in dev slack on 9/20/21, this fixes an issue that causes an error when xgboost is trained using keyword arguments.

For example, if [the example code](https://github.com/allegroai/clearml/blob/master/examples/frameworks/xgboost/xgboost_sample.py#39) is changed from
`bst = xgb.train(param, dtrain, num_round)`
to 
`bst = xgb.train(params=param, dtrain=dtrain, num_boost_round=num_round) `
We receive the following error:  `TypeError: _train() missing 1 required positional argument: '_PatchXGBoostModelIO__obj'`

This minor change fixes that issue. 