### PR TITLE
Search for Repo with OS to Avoid Windows Error

### DIFF
--- a/clearml/backend_interface/task/populate.py
+++ b/clearml/backend_interface/task/populate.py
@@ -618,7 +618,7 @@ if __name__ == '__main__':
             function_name=function_name,
             function_return=function_return)
 
-        temp_dir = repo if repo and Path(repo).is_dir() else None
+        temp_dir = repo if repo and os.path.isdir(repo) else None
         with tempfile.NamedTemporaryFile('w', suffix='.py', dir=temp_dir) as temp_file:
             temp_file.write(task_template)
             temp_file.flush()


### PR DESCRIPTION
Fixes a small Windows-only bug. 

Per #461, `"http://"` throws an `OSError` on Windows which is not handled by `Pathlib2` but returns False in `os.path`.