### PR TITLE
Fix docstring typos

### DIFF
--- a/clearml/automation/job.py
+++ b/clearml/automation/job.py
@@ -436,7 +436,7 @@ class ClearmlJob(BaseJob):
     ):
         # type: (...) -> ()
         """
-        Create a new Task based in a base_task_id with a different set of parameters
+        Create a new Task based on a base_task_id with a different set of parameters
 
         :param str base_task_id: base task id to clone from
         :param dict parameter_override: dictionary of parameters and values to set fo the cloned task

--- a/clearml/automation/monitor.py
+++ b/clearml/automation/monitor.py
@@ -81,7 +81,7 @@ class Monitor(object):
     def monitor_step(self):
         # type: () -> ()
         """
-        Implement the main query / interface of he monitor class.
+        Implement the main query / interface of the monitor class.
         In order to combine multiple Monitor objects, call `monitor_step` manually.
         If Tasks are detected in this call,
 
@@ -130,7 +130,7 @@ class Monitor(object):
         # type: (Task) -> ()
         Abstract function
 
-        Called on every Task that we monitor. For example monitoring failed Task,
+        Called on every Task that we monitor. For example, monitoring failed Task,
         will call this Task the first time the Task was detected as failed.
 
         :return: None

--- a/clearml/automation/optuna/optuna.py
+++ b/clearml/automation/optuna/optuna.py
@@ -106,9 +106,9 @@ class OptimizerOptuna(SearchStrategy):
     ):
         # type: (...) -> None
         """
-        Initialize am Optuna search strategy optimizer
+        Initialize an Optuna search strategy optimizer
         Optuna performs robust and efficient hyperparameter optimization at scale by combining.
-        Specific hyper-parameter pruning strategy can be selected via `sampler` and `pruner` arguments
+        Specific hyperparameter pruning strategy can be selected via `sampler` and `pruner` arguments
 
         :param str base_task_id: Task ID (str)
         :param list hyper_parameters: list of Parameter objects to optimize over

--- a/clearml/automation/scheduler.py
+++ b/clearml/automation/scheduler.py
@@ -580,7 +580,7 @@ class TaskScheduler(BaseScheduler):
         :param single_instance: If True, do not launch the Task job if the previous instance is still running
         (skip until the next scheduled time period). Default False.
         :param recurring: If False only launch the Task once (default: True, repeat)
-        :param execute_immediately: If True, schedule the Task to be execute immediately
+        :param execute_immediately: If True, schedule the Task to be executed immediately
         then recurring based on the timing schedule arguments. Default False.
         :param reuse_task: If True, re-enqueue the same Task (i.e. do not clone it) every time, default False.
         :param task_parameters: Configuration parameters to the executed Task.

--- a/clearml/config/default/sdk.conf
+++ b/clearml/config/default/sdk.conf
@@ -163,7 +163,7 @@
         # If this flag is true (default is false), instead of analyzing the code with Pigar, analyze with `pip freeze`
         detect_with_pip_freeze: false
 
-        # Log specific environment variables. OS environments are enlisted in the "Environment" section
+        # Log specific environment variables. OS environments are listed in the "Environment" section
         # of the Hyper-Parameters.
         # multiple selected variables are supported including the suffix '*'.
         # For example: "AWS_*" will log any OS environment variable starting with 'AWS_'.

--- a/docs/clearml.conf
+++ b/docs/clearml.conf
@@ -179,7 +179,7 @@ sdk {
         # as comments inside the "Installed packages" section
         detailed_import_report: false
 
-        # Log specific environment variables. OS environments are enlisted in the "Environment" section
+        # Log specific environment variables. OS environments are listed in the "Environment" section
         # of the Hyper-Parameters.
         # multiple selected variables are supported including the suffix '*'.
         # For example: "AWS_*" will log any OS environment variable starting with 'AWS_'.

--- a/docs/trains.conf
+++ b/docs/trains.conf
@@ -176,7 +176,7 @@ sdk {
         detect_with_pip_freeze: false
         detect_with_conda_freeze: false
 
-        # Log specific environment variables. OS environments are enlisted in the "Environment" section
+        # Log specific environment variables. OS environments are listed in the "Environment" section
         # of the Hyper-Parameters.
         # multiple selected variables are supported including the suffix '*'.
         # For example: "AWS_*" will log any OS environment variable starting with 'AWS_'.


### PR DESCRIPTION
based in >>> based on
of he >>> of the
for example >>> for example, 
am Optuna >>> an Optuna
hyper-parameter >>> hyperparameter [for consistency, previous line uses without dashes]
to be execute >>> to be executed
enlisted >>> listed