### PR TITLE
fix S3BucketConfig.is_valid for ec2 envs

### DIFF
--- a/clearml/backend_config/bucket_config.py
+++ b/clearml/backend_config/bucket_config.py
@@ -40,7 +40,7 @@ class S3BucketConfig(object):
         self.use_credentials_chain = use_credentials_chain
 
     def is_valid(self):
-        return self.key and self.secret
+        return (self.key and self.secret) or self.use_credentials_chain
 
     def get_bucket_host(self):
         return self.bucket, self.host


### PR DESCRIPTION
In this PR:

- Fix `Exception: Missing credentials` raised when `use_credentials_chain: true` in clearml.conf