### PR TITLE
Add better input handling for clearml-init in colab

### DIFF
--- a/clearml/cli/config/__main__.py
+++ b/clearml/cli/config/__main__.py
@@ -54,6 +54,10 @@ def main():
         default=default_config_file,
         type=validate_file
     )
+    p.add_argument(
+        "--colab", "-c", help="Add if running from a colab instance, input parsing is different",
+        action='store_true'
+    )
 
     args = p.parse_args()
 
@@ -67,10 +71,18 @@ def main():
     print(description, end='')
     sentinel = ''
     parse_input = ''
-    for line in iter(input, sentinel):
-        parse_input += line+'\n'
-        if line.rstrip() == '}':
-            break
+    if args.colab:
+        # When running from a colab instance and calling clearml-init
+        # colab will squish the api credentials into a single line
+        # The regex splits this single line based on 2 spaces or more
+        import re
+        api_input = input()
+        parse_input = '\n'.join(re.split(r" {2,}", api_input))
+    else:
+        for line in iter(input, sentinel):
+            parse_input += line+'\n'
+            if line.rstrip() == '}':
+                break
     credentials = None
     api_server = None
     web_server = None

--- a/clearml/cli/config/__main__.py
+++ b/clearml/cli/config/__main__.py
@@ -54,10 +54,6 @@ def main():
         default=default_config_file,
         type=validate_file
     )
-    p.add_argument(
-        "--colab", "-c", help="Add if running from a colab instance, input parsing is different",
-        action='store_true'
-    )
 
     args = p.parse_args()
 
@@ -71,7 +67,8 @@ def main():
     print(description, end='')
     sentinel = ''
     parse_input = ''
-    if args.colab:
+    # COLAB_GPU will always be available, even when running on CPU
+    if os.environ.get('COLAB_GPU'):
         # When running from a colab instance and calling clearml-init
         # colab will squish the api credentials into a single line
         # The regex splits this single line based on 2 spaces or more


### PR DESCRIPTION
It's specifically for use in Google Colab. A Colab instance always has the `COLAB_GPU` environment variable (this only one that's distinctive afaik). It even has the env var when you have a CPU or TPU runtime, in those cases it just says `COLAB_GPU=0`.

Fixes issue #514 