### PR TITLE
Run HPO locally using LocalClearmlJob

### DIFF
--- a/clearml/automation/job.py
+++ b/clearml/automation/job.py
@@ -572,7 +572,8 @@ class ClearmlJob(BaseJob):
 
 class LocalClearmlJob(ClearmlJob):
     """
-    Run jobs locally as a sub-process, use for debugging purposes only
+    Run jobs locally as a sub-process, use only when no agents are available (this will not use queues)
+    or for debug purposes.
     """
     def __init__(self, *args, **kwargs):
         super(LocalClearmlJob, self).__init__(*args, **kwargs)

--- a/clearml/cli/config/__main__.py
+++ b/clearml/cli/config/__main__.py
@@ -54,6 +54,10 @@ def main():
         default=default_config_file,
         type=validate_file
     )
+    p.add_argument(
+        "--colab", "-c", help="Add if running from a colab instance, input parsing is different",
+        action='store_true'
+    )
 
     args = p.parse_args()
 
@@ -67,10 +71,18 @@ def main():
     print(description, end='')
     sentinel = ''
     parse_input = ''
-    for line in iter(input, sentinel):
-        parse_input += line+'\n'
-        if line.rstrip() == '}':
-            break
+    if args.colab:
+        # When running from a colab instance and calling clearml-init
+        # colab will squish the api credentials into a single line
+        # The regex splits this single line based on 2 spaces or more
+        import re
+        api_input = input()
+        parse_input = '\n'.join(re.split(r" {2,}", api_input))
+    else:
+        for line in iter(input, sentinel):
+            parse_input += line+'\n'
+            if line.rstrip() == '}':
+                break
     credentials = None
     api_server = None
     web_server = None

--- a/clearml/cli/config/__main__.py
+++ b/clearml/cli/config/__main__.py
@@ -54,10 +54,6 @@ def main():
         default=default_config_file,
         type=validate_file
     )
-    p.add_argument(
-        "--colab", "-c", help="Add if running from a colab instance, input parsing is different",
-        action='store_true'
-    )
 
     args = p.parse_args()
 
@@ -71,7 +67,8 @@ def main():
     print(description, end='')
     sentinel = ''
     parse_input = ''
-    if args.colab:
+    # COLAB_GPU will always be available, even when running on CPU
+    if os.environ.get('COLAB_GPU'):
         # When running from a colab instance and calling clearml-init
         # colab will squish the api credentials into a single line
         # The regex splits this single line based on 2 spaces or more

--- a/examples/optimization/hyper-parameter-optimization/hyper_parameter_optimizer.py
+++ b/examples/optimization/hyper-parameter-optimization/hyper_parameter_optimizer.py
@@ -119,6 +119,8 @@ an_optimizer.set_report_period(2.2)
 # start the optimization process, callback function to be called every time an experiment is completed
 # this function returns immediately
 an_optimizer.start(job_complete_callback=job_complete_callback)
+# You can also use the line below instead to run all the optimizer tasks locally, without using queues or agent
+# an_optimizer.start_locally(job_complete_callback=job_complete_callback)
 # set the time limit for the optimization process (2 hours)
 an_optimizer.set_time_limit(in_minutes=120.0)
 # wait until process is done (notice we are controlling the optimization process in the background)


### PR DESCRIPTION
Solves issue #520 

Opted for a `run_locally()` method instead of adding the option as an argument to `.run()` because it is more inline with how ClearML pipelines manage the same functionality.

https://github.com/allegroai/clearml/blob/master/clearml/automation/controller.py#L703

-> Added the method, copied most of the docstring from `.start()` method, it also handles the same arguments
-> Changed LocalClearmlJob docstring to not only include the debugging usecase
-> Added the `.start_locally()` to the HPO example

Tested it locally, with GridSearch and Optuna. Callback function functionality works too.