### PR TITLE
Add some convenience functionality to clearml-data

### DIFF
--- a/clearml/backend_interface/util.py
+++ b/clearml/backend_interface/util.py
@@ -52,6 +52,15 @@ def make_message(s, **kwargs):
     return s % args
 
 
+def does_project_exist(session, project_name):
+    res = session.send(projects.GetAllRequest(name=exact_match_regex(project_name), only_fields=['id']))
+    if not res:
+        return None
+    if res.response and res.response.projects:
+        return True
+    return False
+
+
 def get_or_create_project(session, project_name, description=None):
     res = session.send(projects.GetAllRequest(name=exact_match_regex(project_name), only_fields=['id']))
     if not res:

--- a/clearml/backend_interface/util.py
+++ b/clearml/backend_interface/util.py
@@ -52,23 +52,28 @@ def make_message(s, **kwargs):
     return s % args
 
 
-def does_project_exist(session, project_name):
-    res = session.send(projects.GetAllRequest(name=exact_match_regex(project_name), only_fields=['id']))
-    if not res:
-        return None
-    if res.response and res.response.projects:
-        return True
-    return False
-
-
-def get_or_create_project(session, project_name, description=None):
+def get_existing_project(session, project_name):
+    """Return either the project ID if it exists, an empty string if it doesn't or None if backend request failed."""
     res = session.send(projects.GetAllRequest(name=exact_match_regex(project_name), only_fields=['id']))
     if not res:
         return None
     if res.response and res.response.projects:
         return res.response.projects[0].id
-    res = session.send(projects.CreateRequest(name=project_name, description=description or ''))
-    return res.response.id
+    return ""
+
+
+def get_or_create_project(session, project_name, description=None):
+    """Return the ID of an existing project, or if it does not exist, make a new one and return that ID instead."""
+    project_id = get_existing_project(session, project_name)
+    if project_id:
+        return project_id
+    if project_id == "":
+        # Project was not found, so create a new one
+        res = session.send(projects.CreateRequest(name=project_name, description=description or ''))
+        return res.response.id
+
+    # This should only happen if backend response was None and so project_id is also None
+    return None
 
 
 def get_queue_id(session, queue):

--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -929,7 +929,8 @@ class Dataset(object):
             raise ValueError("Dataset selection criteria not met. Didn't provide id/name/project/tags correctly.")
 
         if auto_create and not get_existing_project(
-                session=Task._get_default_session(), project_name=dataset_project):
+            session=Task._get_default_session(), project_name=dataset_project
+        ):
             tasks = []
         else:
             tasks = Task.get_tasks(


### PR DESCRIPTION
Added some extra functionality to the `clearml-data` api to support the following use-case:

Say I have a data labeling flow. With as little lines of code as possible, I want to add functionality that quickly creates a new version of my labeled dataset based on the last version, that adds some new labeled samples. Just to keep track of my iterative updates to the dataset, be able to easily share the latest one and  not have to upload all samples every time.

To allow for this I made 3 changes:


1. Create a flag that implicitly creates a dataset and project while running `Dataset.get` if it does not exist yet.

In this way I don't have to either manually create a dataset when I want to start a new labeling process or first check if it exists with a `try catch` block around `Dataset.get` and create a new one on error. Just adding the flag now takes care of that, so I only need 1 line to get or create my dataset.

2. Allow to get a writable copy of the latest dataset by implicitly creating a new one with the latest one as its parent.

Intuitively, this makes a lot of sense. I want to get my dataset, add new files to it and then push the new version up again. This allows me to do just that by creating a new child version.

3. Add automatic upload to the finalize call.

This is quite simply for convenience, less lines. The CLI command will automatically upload all files when finalize is called, so it should be possible to do the same in Python if you want to and are not in need of the extra upload parameters.



None of these changes are breaking current default behaviour, they just aim to add convenience for this type of workflow. 