### PR TITLE
Bug fix: Auto-scaler should not spin a new instance with task_id = None 

### DIFF
--- a/clearml/automation/cloud_driver.py
+++ b/clearml/automation/cloud_driver.py
@@ -39,7 +39,6 @@ export CLEARML_WORKER_ID={worker_prefix}:$DYNAMIC_INSTANCE_ID
 export CLEARML_API_ACCESS_KEY='{access_key}'
 export CLEARML_API_SECRET_KEY='{secret_key}'
 export CLEARML_AUTH_TOKEN='{auth_token}'
-source ~/.bashrc
 {bash_script}
 {driver_extra}
 python -m clearml_agent --config-file ~/clearml.conf daemon --queue '{queue}' {docker}


### PR DESCRIPTION
Hi, after [a discussion](https://clearml.slack.com/archives/CTK20V944/p1641490355015400) from clearml-community Slack channel, I figured out the solution and decided to make this PR.
Thanks in advance for your feedbacks.