### PR TITLE
Fix/click

### DIFF
--- a/clearml/binding/click_bind.py
+++ b/clearml/binding/click_bind.py
@@ -15,7 +15,6 @@ class PatchClick:
     _args_type = {}
     _num_commands = 0
     _command_type = 'click.Command'
-    _group_type = 'click.Group'
     _section_name = 'Args'
     _main_task = None
     __remote_task_params = None
@@ -67,7 +66,7 @@ class PatchClick:
 
     @staticmethod
     def _command_init(original_fn, self, *args, **kwargs):
-        if self and (isinstance(self, Command) or isinstance(self, Group)) and 'name' in kwargs:
+        if self and isinstance(self, Command) and isinstance(self, Group) and 'name' in kwargs:
             if isinstance(self, Command):
                 PatchClick._num_commands += 1
             if not running_remotely():
@@ -76,8 +75,6 @@ class PatchClick:
                     PatchClick._args[name] = False
                     if isinstance(self, Command):
                         PatchClick._args_type[name] = PatchClick._command_type
-                    else:
-                        PatchClick._args_type[name] = PatchClick._group_type
                     # maybe we should take it post initialization
                     if kwargs.get('help'):
                         PatchClick._args_desc[name] = str(kwargs.get('help'))
@@ -111,7 +108,7 @@ class PatchClick:
 
         ret = original_fn(self, *args, **kwargs)
 
-        if isinstance(self, Command): # and not isinstance(self, Group):
+        if isinstance(self, Command):
             ctx = kwargs.get('ctx') or args[0]
             if running_remotely():
                 PatchClick._load_task_params()

--- a/clearml/binding/click_bind.py
+++ b/clearml/binding/click_bind.py
@@ -15,6 +15,7 @@ class PatchClick:
     _args_type = {}
     _num_commands = 0
     _command_type = 'click.Command'
+    _group_type = 'click.Group'
     _section_name = 'Args'
     _main_task = None
     __remote_task_params = None
@@ -66,15 +67,17 @@ class PatchClick:
 
     @staticmethod
     def _command_init(original_fn, self, *args, **kwargs):
-        if self and isinstance(self, Command) and 'name' in kwargs:
-            PatchClick._num_commands += 1
-            if running_remotely():
-                pass
-            else:
+        if self and (isinstance(self, Command) or isinstance(self, Group)) and 'name' in kwargs:
+            if isinstance(self, Command):
+                PatchClick._num_commands += 1
+            if not running_remotely():
                 name = kwargs['name']
                 if name:
                     PatchClick._args[name] = False
-                    PatchClick._args_type[name] = PatchClick._command_type
+                    if isinstance(self, Command):
+                        PatchClick._args_type[name] = PatchClick._command_type
+                    else:
+                        PatchClick._args_type[name] = PatchClick._group_type
                     # maybe we should take it post initialization
                     if kwargs.get('help'):
                         PatchClick._args_desc[name] = str(kwargs.get('help'))
@@ -96,7 +99,7 @@ class PatchClick:
 
     @staticmethod
     def _parse_args(original_fn, self, *args, **kwargs):
-        if running_remotely() and isinstance(self, Command) and isinstance(self, Group):
+        if running_remotely() and (isinstance(self, Command) or isinstance(self, Group)):
             command = PatchClick._load_task_params()
             if command:
                 init_args = kwargs['args'] if 'args' in kwargs else args[1]
@@ -108,7 +111,7 @@ class PatchClick:
 
         ret = original_fn(self, *args, **kwargs)
 
-        if isinstance(self, Command) and not isinstance(self, Group):
+        if isinstance(self, Command): # and not isinstance(self, Group):
             ctx = kwargs.get('ctx') or args[0]
             if running_remotely():
                 PatchClick._load_task_params()
@@ -118,7 +121,8 @@ class PatchClick:
                     ctx.params[p.name] = p.process_value(
                         ctx, cast_str_to_bool(value, strip=True) if isinstance(p.type, BoolParamType) else value)
             else:
-                PatchClick._args[self.name] = True
+                if not isinstance(self, Group):
+                    PatchClick._args[self.name] = True
                 for k, v in ctx.params.items():
                     # store passed value
                     PatchClick._args[self.name + '/' + str(k)] = str(v or '')

--- a/clearml/binding/click_bind.py
+++ b/clearml/binding/click_bind.py
@@ -66,7 +66,7 @@ class PatchClick:
 
     @staticmethod
     def _command_init(original_fn, self, *args, **kwargs):
-        if self and (isinstance(self, Command) or isinstance(self, Group)) and 'name' in kwargs:
+        if isinstance(self, (Command, Group)) and 'name' in kwargs:
             if isinstance(self, Command):
                 PatchClick._num_commands += 1
             if not running_remotely():

--- a/clearml/binding/click_bind.py
+++ b/clearml/binding/click_bind.py
@@ -66,7 +66,7 @@ class PatchClick:
 
     @staticmethod
     def _command_init(original_fn, self, *args, **kwargs):
-        if self and isinstance(self, Command) and isinstance(self, Group) and 'name' in kwargs:
+        if self and (isinstance(self, Command) or isinstance(self, Group)) and 'name' in kwargs:
             if isinstance(self, Command):
                 PatchClick._num_commands += 1
             if not running_remotely():
@@ -96,7 +96,7 @@ class PatchClick:
 
     @staticmethod
     def _parse_args(original_fn, self, *args, **kwargs):
-        if running_remotely() and (isinstance(self, Command) or isinstance(self, Group)):
+        if running_remotely() and isinstance(self, Command) and isinstance(self, Group):
             command = PatchClick._load_task_params()
             if command:
                 init_args = kwargs['args'] if 'args' in kwargs else args[1]

--- a/examples/frameworks/click/click_multi_cmd.py
+++ b/examples/frameworks/click/click_multi_cmd.py
@@ -3,9 +3,12 @@ from clearml import Task
 
 
 @click.group()
-def cli():
-    task = Task.init(project_name='examples', task_name='click multi command')
-    print('done')
+@click.option('--print-something/--dont-print-something', default=True)
+@click.option('--what-to-print', default='something')
+def cli(print_something, what_to_print):
+    Task.init(project_name='examples', task_name='click multi command')
+    if print_something:
+        print(what_to_print)
 
 
 @cli.command('hello', help='test help')
@@ -15,7 +18,6 @@ def hello(count, name):
     """Simple program that greets NAME for a total of COUNT times."""
     for x in range(count):
         click.echo("Hello {}!".format(name))
-    print('done')
 
 
 CONTEXT_SETTINGS = dict(


### PR DESCRIPTION
Fix group arguments in click. Arguments from group commands such as the one seen in `click_multi_cmd.py` would be ignored by ClearML before this patch.