### PR TITLE
Fix/argparse warning

### DIFF
--- a/clearml/binding/args.py
+++ b/clearml/binding/args.py
@@ -37,15 +37,23 @@ class PatchArgumentParser:
     @staticmethod
     def parse_args(self, args=None, namespace=None):
         if PatchArgumentParser._recursion_guard:
-            return {} if not PatchArgumentParser._original_parse_args else \
-                PatchArgumentParser._original_parse_args(self, args=args, namespace=namespace)
+            return (
+                {}
+                if not PatchArgumentParser._original_parse_args
+                else PatchArgumentParser._original_parse_args(self, args=args, namespace=namespace)
+            )
 
         PatchArgumentParser._recursion_guard = True
         try:
             result = PatchArgumentParser._patched_parse_args(
-                PatchArgumentParser._original_parse_args, self, args=args, namespace=namespace)
+                PatchArgumentParser._original_parse_args, self, args=args, namespace=namespace
+            )
         except Exception as e:
-            result = None
+            result = (
+                {}
+                if not PatchArgumentParser._original_parse_args
+                else PatchArgumentParser._original_parse_args(self, args=args, namespace=namespace)
+            )
             warnings.warn("Error when patching arguments: %s" % e)
         finally:
             PatchArgumentParser._recursion_guard = False
@@ -54,15 +62,23 @@ class PatchArgumentParser:
     @staticmethod
     def parse_known_args(self, args=None, namespace=None):
         if PatchArgumentParser._recursion_guard:
-            return {} if not PatchArgumentParser._original_parse_args else \
-                PatchArgumentParser._original_parse_known_args(self, args=args, namespace=namespace)
+            return (
+                {}
+                if not PatchArgumentParser._original_parse_args
+                else PatchArgumentParser._original_parse_known_args(self, args=args, namespace=namespace)
+            )
 
         PatchArgumentParser._recursion_guard = True
         try:
             result = PatchArgumentParser._patched_parse_args(
-                PatchArgumentParser._original_parse_known_args, self, args=args, namespace=namespace)
+                PatchArgumentParser._original_parse_known_args, self, args=args, namespace=namespace
+            )
         except Exception as e:
-            result = None
+            result = (
+                {}
+                if not PatchArgumentParser._original_parse_args
+                else PatchArgumentParser._original_parse_known_args(self, args=args, namespace=namespace)
+            )
             warnings.warn("Error when patching arguments: %s" % e)
         finally:
             PatchArgumentParser._recursion_guard = False

--- a/clearml/binding/args.py
+++ b/clearml/binding/args.py
@@ -54,7 +54,7 @@ class PatchArgumentParser:
                 if not PatchArgumentParser._original_parse_args
                 else PatchArgumentParser._original_parse_args(self, args=args, namespace=namespace)
             )
-            warnings.warn("Error when patching arguments: %s" % e)
+            warnings.warn("Failed patching argparse arguments: %s" % e)
         finally:
             PatchArgumentParser._recursion_guard = False
         return result
@@ -79,7 +79,7 @@ class PatchArgumentParser:
                 if not PatchArgumentParser._original_parse_args
                 else PatchArgumentParser._original_parse_known_args(self, args=args, namespace=namespace)
             )
-            warnings.warn("Error when patching arguments: %s" % e)
+            warnings.warn("Failed patching argparse arguments: %s" % e)
         finally:
             PatchArgumentParser._recursion_guard = False
         return result
@@ -250,7 +250,7 @@ def patch_argparse():
 try:
     patch_argparse()
 except Exception as e:
-    warnings.warn("Error when patching argparse: %s" % e)
+    warnings.warn("Failed patching argparse: %s" % e)
 
 
 def call_original_argparser(self, args=None, namespace=None):

--- a/clearml/binding/args.py
+++ b/clearml/binding/args.py
@@ -1,5 +1,6 @@
 """ Argparse utilities"""
 import sys
+import warnings
 from copy import copy
 
 from six import PY2
@@ -43,6 +44,9 @@ class PatchArgumentParser:
         try:
             result = PatchArgumentParser._patched_parse_args(
                 PatchArgumentParser._original_parse_args, self, args=args, namespace=namespace)
+        except Exception as e:
+            result = None
+            warnings.warn("Error when patching arguments: %s" % e)
         finally:
             PatchArgumentParser._recursion_guard = False
         return result
@@ -57,6 +61,9 @@ class PatchArgumentParser:
         try:
             result = PatchArgumentParser._patched_parse_args(
                 PatchArgumentParser._original_parse_known_args, self, args=args, namespace=namespace)
+        except Exception as e:
+            result = None
+            warnings.warn("Error when patching arguments: %s" % e)
         finally:
             PatchArgumentParser._recursion_guard = False
         return result
@@ -224,7 +231,10 @@ def patch_argparse():
 
 
 # Notice! we are patching argparser, so we know if someone parsed arguments before connecting to task
-patch_argparse()
+try:
+    patch_argparse()
+except Exception as e:
+    warnings.warn("Error when patching argparse: %s" % e)
 
 
 def call_original_argparser(self, args=None, namespace=None):


### PR DESCRIPTION
When there is an issue patching the Argparser raise a warning for the user (so it won't fail running remotely).