### PR TITLE
Fix/dataset nothing to upload

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -401,7 +401,7 @@ class Dataset(object):
             else:
                 total_size += zip_file.stat().st_size
                 # update the artifact preview
-                archive_preview = 'Dataset archive content [{} files]:\n'.format(count) + archive_preview
+                archive_preview = "Dataset archive content [{} files]:\n".format(count) + archive_preview
                 # add into the list
                 list_zipped_artifacts += [(zip_file, count, archive_preview, self._data_artifact_name)]
             # let's see what's left
@@ -413,10 +413,12 @@ class Dataset(object):
             a_tqdm.close()
 
         self._task.get_logger().report_text(
-            'File compression completed: total size {}, {} chunked stored (average size {})'.format(
+            "File compression completed: total size {}, {} chunked stored (average size {})".format(
                 format_size(total_size),
                 len(list_zipped_artifacts),
-                format_size(0 if len(list_zipped_artifacts) == 0 else total_size / len(list_zipped_artifacts))))
+                format_size(0 if len(list_zipped_artifacts) == 0 else total_size / len(list_zipped_artifacts)),
+            )
+        )
 
         if not list_zipped_artifacts:
             LoggerRoot.get_base_logger().info('No pending files, skipping upload.')

--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -398,14 +398,14 @@ class Dataset(object):
 
             if not count:
                 zip_file.unlink()
-
-            total_size += zip_file.stat().st_size
+            else:
+                total_size += zip_file.stat().st_size
+                # update the artifact preview
+                archive_preview = 'Dataset archive content [{} files]:\n'.format(count) + archive_preview
+                # add into the list
+                list_zipped_artifacts += [(zip_file, count, archive_preview, self._data_artifact_name)]
             # let's see what's left
             list_file_entries = list_file_entries[processed:]
-            # update the artifact preview
-            archive_preview = 'Dataset archive content [{} files]:\n'.format(count) + archive_preview
-            # add into the list
-            list_zipped_artifacts += [(zip_file, count, archive_preview, self._data_artifact_name)]
             # next artifact name to use
             self._data_artifact_name = self._get_next_data_artifact_name(self._data_artifact_name)
 
@@ -416,7 +416,7 @@ class Dataset(object):
             'File compression completed: total size {}, {} chunked stored (average size {})'.format(
                 format_size(total_size),
                 len(list_zipped_artifacts),
-                format_size(total_size / len(list_zipped_artifacts))))
+                format_size(0 if len(list_zipped_artifacts) == 0 else total_size / len(list_zipped_artifacts))))
 
         if not list_zipped_artifacts:
             LoggerRoot.get_base_logger().info('No pending files, skipping upload.')


### PR DESCRIPTION
Dataset.upload() crashes if there is nothing to upload. This patch fixes this problem by skipping empty zip files.

 To reproduce:

```
import argparse
import os
from clearml import Dataset

INIT_DIR = "init_dir"
REPRODUCE_SAME_DIR = "reproduce_same_dir"
REPRODUCE_EMPTY_DIR = "reproduce_empty_dir"
FILE_NAME = "reproduce.txt"
FILE_TEXT = "something"


def init():
    try:
        os.makedirs(INIT_DIR)
    except:
        pass
    with open(os.path.join(INIT_DIR, FILE_NAME), "w") as f:
        f.write(FILE_TEXT)
    ds = Dataset.create(
        dataset_name=REPRODUCE_SAME_DIR, dataset_project="datasets", parent_datasets=None, use_current_task=True
    )
    ds.add_files(INIT_DIR)
    ds.upload(output_url=None)
    ds.finalize()
    ds._task.mark_completed()
    ds.publish()


def reproduce_same(parent_id):
    try:
        os.makedirs(REPRODUCE_SAME_DIR)
    except:
        pass
    with open(os.path.join(REPRODUCE_SAME_DIR, FILE_NAME), "w") as f:
        f.write(FILE_TEXT)
    parent = [Dataset.get(dataset_id=parent_id).id]
    ds = Dataset.create(
        dataset_name=REPRODUCE_SAME_DIR, dataset_project="datasets", parent_datasets=parent, use_current_task=True
    )
    ds.add_files(REPRODUCE_SAME_DIR)
    ds.upload(output_url=None)
    ds.finalize()
    ds._task.mark_completed()
    ds.publish()


def reproduce_empty(parent_id):
    try:
        os.makedirs(REPRODUCE_EMPTY_DIR)
    except:
        pass
    parent = [Dataset.get(dataset_id=parent_id).id]
    ds = Dataset.create(
        dataset_name=REPRODUCE_EMPTY_DIR, dataset_project="datasets", parent_datasets=parent, use_current_task=True
    )
    ds.add_files(REPRODUCE_EMPTY_DIR)
    ds.upload(output_url=None)
    ds.finalize()
    ds._task.mark_completed()
    ds.publish()


if __name__ == "__main__":
    ap = argparse.ArgumentParser()
    ap.add_argument("--init", action="store_true")
    ap.add_argument("--reproduce-same", action="store_true")
    ap.add_argument("--reproduce-empty", action="store_true")
    ap.add_argument("--parent-id", default=None)
    args = ap.parse_args()
    if args.init:
        init()
    elif args.reproduce_same:
        reproduce_same(args.parent_id)
    elif args.reproduce_empty:
        reproduce_empty(args.parent_id)
    else:
        print("Choose what to do")
```