### PR TITLE
Update Slack SDK requirement

### DIFF
--- a/examples/services/monitoring/requirements.txt
+++ b/examples/services/monitoring/requirements.txt
@@ -1,2 +1,2 @@
 clearml
-slackclient > 2.0.0
+slack_sdk > 3.0.0


### PR DESCRIPTION
Cf [https://github.com/allegroai/clearml-server/issues/113](https://github.com/allegroai/clearml-server/issues/113)

Slack SDK requirement was out of date and `from slack_sdk import WebClient` was failing. This PR updates the requirement from `slackclient` to `slack_sdk` as per [the docs](https://slack.dev/python-slack-sdk/v3-migration/index.html#from-slackclient-2-x)
