### PR TITLE
Fix DeprecationWarning triggered by implicit int conversion

### DIFF
--- a/clearml/backend_interface/task/development/worker.py
+++ b/clearml/backend_interface/task/development/worker.py
@@ -54,10 +54,10 @@ class DevWorker(object):
         last_ping = time()
         while self._task is not None:
             try:
-                if self._exit_event.wait(min(self.ping_period, self.report_period)):
+                if self._exit_event.wait(min(int(self.ping_period), int(self.report_period))):
                     return
                 # send ping request
-                if self._support_ping and (time() - last_ping) >= self.ping_period:
+                if self._support_ping and (time() - last_ping) >= int(self.ping_period):
                     self.ping()
                     last_ping = time()
                 if self._dev_stop_signal:


### PR DESCRIPTION
In recent versions of Python, there's a warning triggered by `_daemon` function:

```
DeprecationWarning: an integer is required (got type LazyEvalWrapper).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
```

Use explicit conversion to avoid it.