### PR TITLE
Add git credentials to colab example

### DIFF
--- a/examples/clearml_agent/clearml_colab_agent.ipynb
+++ b/examples/clearml_agent/clearml_colab_agent.ipynb
@@ -1,29 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "clearml_colab_agent.ipynb",
-      "provenance": [],
-      "collapsed_sections": [],
-      "toc_visible": true,
-      "authorship_tag": "ABX9TyMKeTOHrlQb98s9lDHxWFts",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/allegroai/clearml/blob/master/examples/clearml_agent/clearml_colab_agent.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -49,15 +30,15 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "DwFC3fL8JAP3"
       },
+      "outputs": [],
       "source": [
         "!pip install clearml\n",
         "!pip install clearml-agent"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -72,14 +53,33 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "3-Bm4811VMLK"
       },
+      "outputs": [],
       "source": [
-        "! export MPLBACKEND=TkAg\n"
-      ],
+        "! export MPLBACKEND=TkAg"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Step 2b (OPTIONAL): Enter your github credentials\n",
+        "In order for the agent to pull your code, it needs access to your repositories. If these are private, you'll have to supply the agent with github credentials to log in. Github/Bitbucket will no longer let you log in using username/password combinations. Instead, you have to use a personal token, read more about it [here for Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and [here for Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)"
+      ]
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
-      "outputs": []
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "os.environ[\"CLEARML_AGENT_GIT_USER\"] = \"username-goes-here\"\n",
+        "os.environ[\"CLEARML_AGENT_GIT_PASS\"] = \"git-personal-access-token\""
+      ]
     },
     {
       "cell_type": "markdown",
@@ -108,9 +108,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "YBPdmP4sJHnQ"
       },
+      "outputs": [],
       "source": [
         "#@title Insert your own Credentials\n",
         "\n",
@@ -129,20 +131,16 @@
         "                     secret=secret_key\n",
         "                     )\n",
         "  \n"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "DStY3iZnRpYb"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": []
     },
     {
       "cell_type": "markdown",
@@ -155,14 +153,37 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "QcczeU7OJ9G-"
       },
+      "outputs": [],
       "source": [
         "!clearml-agent daemon --queue default"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "authorship_tag": "ABX9TyMKeTOHrlQb98s9lDHxWFts",
+      "collapsed_sections": [],
+      "include_colab_link": true,
+      "name": "clearml_colab_agent.ipynb",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "interpreter": {
+      "hash": "d75e902da2bbfe9f41879fcf2334f5819447e02a7f656a079df344fef4e78809"
+    },
+    "kernelspec": {
+      "display_name": "Python 3.7.12 64-bit ('.env')",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": ""
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/examples/clearml_agent/clearml_colab_agent.ipynb
+++ b/examples/clearml_agent/clearml_colab_agent.ipynb
@@ -78,9 +78,11 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "#@title Insert your Git Credentials\n",
+        "\n",
         "import os\n",
-        "os.environ[\"CLEARML_AGENT_GIT_USER\"] = \"username-goes-here\"\n",
-        "os.environ[\"CLEARML_AGENT_GIT_PASS\"] = \"git-personal-access-token\""
+        "os.environ[\"CLEARML_AGENT_GIT_USER\"] = \"username-goes-here\" #@param {type:\"string\"}\n",
+        "os.environ[\"CLEARML_AGENT_GIT_PASS\"] = \"git-personal-access-token\" #@param {type:\"string\"}"
       ]
     },
     {

--- a/examples/clearml_agent/clearml_colab_agent.ipynb
+++ b/examples/clearml_agent/clearml_colab_agent.ipynb
@@ -66,8 +66,10 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Step 2b (OPTIONAL): Enter your github credentials\n",
-        "In order for the agent to pull your code, it needs access to your repositories. If these are private, you'll have to supply the agent with github credentials to log in. Github/Bitbucket will no longer let you log in using username/password combinations. Instead, you have to use a personal token, read more about it [here for Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and [here for Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)"
+        "### Step 2b (OPTIONAL): Enter your github credentials (only for private repositories)\n",
+        "In order for the agent to pull your code, it needs access to your repositories. If these are private, you'll have to supply the agent with github credentials to log in. Github/Bitbucket will no longer let you log in using username/password combinations. Instead, you have to use a personal token, read more about it [here for Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) and [here for Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)\n",
+        "\n",
+        "We can let the agent know which credentials to use by setting the following env variables"
       ]
     },
     {


### PR DESCRIPTION
In order for the agent to pull your code, it needs access to your repositories. If these are private, you'll have to supply the agent with github credentials to log in. Github/Bitbucket will no longer let you log in using username/password combinations. Instead, you have to use a personal token.
This PR adds how to do that as an optional cell.