### PR TITLE
cast_basic_type says "False" is True

### DIFF
--- a/clearml/utilities/proxy_object.py
+++ b/clearml/utilities/proxy_object.py
@@ -97,7 +97,8 @@ def cast_basic_type(value, type_str):
     if not type_str:
         return value
 
-    basic_types = {str(getattr(v, '__name__', v)): v for v in (float, int, bool, str, list, tuple, dict)}
+    basic_types = {str(getattr(v, '__name__', v)): v for v in (float, int, str, list, tuple, dict)}
+    basic_types['bool'] = lambda v: False if v == 'False' else True
 
     parts = type_str.split('/')
     # nested = len(parts) > 1


### PR DESCRIPTION
Currently `cast_basic_type("False", "bool") == True`.  This causes issues if you use `task.get_parameters_as_dict(cast=True)`.

This might be related to https://github.com/allegroai/clearml/issues/531

Environment:

* python 3.9
* clearml 1.3.1
* debian

How to reproduce:

```python
from clearml import Task
t = Task.create(project_name="Debugging", task_name="test_get_params")
t.set_parameters_as_dict({"General": {"should_be_false": False}})
t.get_parameters_as_dict(cast=True)["General"]["should_be_false"] # True
```

This PR means that any string except 'False' is True