### PR TITLE
Specify an endpoint_url when creating S3 resource service

### DIFF
--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -1548,6 +1548,7 @@ class _Boto3Driver(_Driver):
             bucket = boto_resource.Bucket(bucket_name)
             bucket.put_object(Key=filename, Body=six.b(json.dumps(data)))
 
+
             region = cls._get_bucket_region(conf=conf, log=log, report_info=True)
             if region and ((conf.region and region != conf.region) or (not conf.region and region != 'us-east-1')):
                 msg = "incorrect region specified for bucket %s (detected region %s)" % (conf.bucket, region)

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -1544,10 +1544,10 @@ class _Boto3Driver(_Driver):
             }
 
             boto_session = boto3.Session(conf.key, conf.secret, aws_session_token=conf.token)
-            boto_resource = boto_session.resource('s3', conf.region)
+            endpoint = (('https://' if cfg.secure else 'http://') + cfg.host) if (conf.host and len(conf.host.split(':')) > 1) else None
+            boto_resource = boto_session.resource('s3', region_name=conf.region, endpoint_url=endpoint)
             bucket = boto_resource.Bucket(bucket_name)
             bucket.put_object(Key=filename, Body=six.b(json.dumps(data)))
-
 
             region = cls._get_bucket_region(conf=conf, log=log, report_info=True)
             if region and ((conf.region and region != conf.region) or (not conf.region and region != 'us-east-1')):


### PR DESCRIPTION
Explicitly specify an endpoint_url when creating S3 resource service for aws compatible bucket.
Fix [issues/673](https://github.com/allegroai/clearml/issues/673)