### PR TITLE
Release lock after dataset cache is downloaded 

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -1692,7 +1692,7 @@ class Dataset(object):
         if lock_target_folder:
             cache.lock_cache_folder(local_folder)
         local_folder.mkdir(parents=True, exist_ok=True)
-        return local_folder, cache
+        return local_folder
 
     def _release_lock_ds_target_folder(self, target_folder):
         # type: () -> None
@@ -1751,7 +1751,7 @@ class Dataset(object):
             num_parts = self.get_num_chunks()
 
         # just create the dataset target folder
-        target_base_folder, cache = self._create_ds_target_folder(
+        target_base_folder = self._create_ds_target_folder(
             part=part, num_parts=num_parts, lock_target_folder=True)
 
         # selected specific chunks if `part` was passed

--- a/clearml/storage/cache.py
+++ b/clearml/storage/cache.py
@@ -261,26 +261,15 @@ class CacheManager(object):
                 atexit.register(self._lock_file_cleanup_callback)
 
             lock = self._folder_locks.get(local_path.as_posix())
-            i = 0
-            # try to create a lock if we do not already have one (if we do, we assume it is locked)
-            while not lock:
-                lock_path = local_path.parent / "{}{:03d}.{}{}".format(
-                    CacheManager._lockfile_prefix,
-                    i,
-                    local_path.name,
-                    CacheManager._lockfile_suffix,
-                )
-                lock = FileLock(filename=lock_path)
-
-                # try to lock folder (if we failed to create lock, try nex number)
-                try:
-                    lock.acquire(timeout=0)
-                    break
-                except LockException:
-                    # failed locking, maybe someone else already locked it.
-                    del lock
-                    lock = None
-                    i += 1
+            # try to create a lock. If it exists, wait for the lock to be released
+            lock_path = local_path.parent / "{}{:03d}.{}{}".format(
+                CacheManager._lockfile_prefix,
+                0,
+                local_path.name,
+                CacheManager._lockfile_suffix,
+            )
+            lock = FileLock(filename=lock_path)
+            lock.acquire(timeout=300, check_interval=1.0)
 
             # store lock
             self._folder_locks[local_path.as_posix()] = lock


### PR DESCRIPTION
Ref: https://github.com/allegroai/clearml/issues/671

Basically, two main changes:

1. once the download of a dataset is completed, the lock is released immediately
2. while a process is downloading a dataset i.e. holding the lock, other processes will wait until the lock is released (in the current fix, after 5 min of wait there's a timeout error raise. But this can be changed)