### PR TITLE
Fix dataset download

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -2121,6 +2121,9 @@ class Dataset(object):
                 extract_archive=False, name=self._id)
             if not local_zip:
                 raise ValueError("Could not download dataset id={} entry={}".format(self._id, data_artifact_name))
+            return local_zip
+
+        def _extract_part(local_zip):
             # noinspection PyProtectedMember
             StorageManager._extract_to_cache(
                 cached_file=local_zip, name=self._id,
@@ -2133,7 +2136,8 @@ class Dataset(object):
 
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             for d in data_artifact_entries:
-                pool.submit(_download_part, d)
+                local_zip = _download_part(d)
+                pool.submit(_extract_part, local_zip)
 
         return local_folder
 


### PR DESCRIPTION
Hello!

We had a [discussion](https://clearml.slack.com/archives/CTK20V944/p1650467326569479) on Slack about a new feature which added support for parallel downloads and extraction of datasets. Using multithreading was supposed to decrease the time which we need to obtain a local dataset copy by unzipping chunks of datasets in the background simultaneously with download. It seems to me that this feature is not working as expected.

So, previously the downloading of each particular dataset was conducted consequently, chunk by chunk. We used to download a chunk of data, extract it right after downloading ends and only after that take another chunk. The problem with that approach was that we were waiting a lot of time during zip extraction, which could be spent on downloading the next chunk. You can see schematic representation of such approach in the next figure:

![image](https://user-images.githubusercontent.com/29747986/177814075-8402b917-feea-40ad-9ed9-0eb3a1c56da0.png)

The current way to download and extract data is the following: each time we call [Dataset.get_local_copy()](https://github.com/allegroai/clearml/blob/e3547cd89770c6d73f92d9a05696018957c3fd62/clearml/datasets/dataset.py#L799)  method we create [a thread pool](https://github.com/allegroai/clearml/blob/e3547cd89770c6d73f92d9a05696018957c3fd62/clearml/datasets/dataset.py#L2134), and provide it with tasks to download and extract chunks of dataset in parallel. It turns out that while N workers are downloading N chunks, downloading speed for each worker is N times less than for a consequent download. Since most of the chunks have the same size, the download processes finish at the same time and the parallel zip extraction process runs again about N times slower than for a single worker mode. During this extraction process we did not utilize the network at all. Moreover, according to my experiments, the more logical cores we use, the longer it takes to extract all chunks simultaneously.

![image](https://user-images.githubusercontent.com/29747986/177814485-bdc5e6e0-2d6e-4663-b414-f175c87f958f.png)

In this request I propose to consider another approach instead of the current one: let us download datasets consequently, utilizing network throughput at maximum for each separate chunk and spawn new extraction tasks to the thread pool each time we finish downloading a part of a data. Furthermore, I question the necessity of using thread pool, because it seems that parallel extraction of zip archives is not really efficient in terms of time - obtaining datasets using several workers took me longer (for both current and proposed approaches), so, I think that we could use only one additional thread.

![image](https://user-images.githubusercontent.com/29747986/177815375-c6c854c0-cf32-4d80-8a17-46222285b1f7.png)

I have tested both current and proposed approaches on several datasets in order to prove my theory. I used the following Python script with different numbers of workers (each time I cleaned the ClearML cache folder before the experiments):

``` python
import time
from clearml import Dataset

dataset_list = ['test_dataset_1', 'test_dataset_2']
time_list = []

for dataset_name in dataset_list:
    start_time = time.time()

    clearml_dataset = Dataset.get(
        dataset_project="SplitNet Data", dataset_name=dataset_name)
    clearml_dataset_path = clearml_dataset.get_local_copy(max_workers=None)

    dataset_time = time.time() - start_time
    time_list.append(dataset_time)
    print(f'Path to {dataset_name}: {clearml_dataset_path} ({dataset_time})')

print(f'Datasets: {dataset_list}')
print(f'List of times: {time_list}')
```

For small datasets there is almost no difference in time between the current and proposed approach (regardless of the number of workers we use), but the difference increases with an increase in the number of dataset chunks. Let us look at two relatively big datasets, which consist of a number of file pairs (pictures and json file). First one contains 7 data chunks (each of them ~500 Mb) and the second one has 22 chunks of data (same size for a chunk). In the following pictures you can see that, at least on my system, the proposed approach allows us to significantly reduce time for obtaining a dataset. You also can see that I did not get any speed up from utilizing more cores for parallel zip extraction.

![test_1](https://user-images.githubusercontent.com/29747986/177794522-e5f37776-dd5f-4a77-bb6f-07df8536f070.png)

![test_2](https://user-images.githubusercontent.com/29747986/177794542-7006c517-8360-47d2-a201-15778dd53c9e.png)

What do you think of that idea? In case you did extensive testing of parallel loading of datasets in terms of time, could you please share your results? What additional information that would be helpful to you can I provide?

I apologize for any inconvenience I might cause. Thank you in advance for your help. I look forward to your response. 