### PR TITLE
Issues with relative paths in examples

### DIFF
--- a/examples/reporting/image_reporting.py
+++ b/examples/reporting/image_reporting.py
@@ -29,7 +29,7 @@ def report_debug_images(logger, iteration=0):
     logger.report_image("image", "image color red", iteration=iteration, image=m)
 
     # report PIL Image object
-    image_open = Image.open(os.path.join("data_samples", "picasso.jpg"))
+    image_open = Image.open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "data_samples", "picasso.jpg"))
     logger.report_image("image", "image PIL", iteration=iteration, image=image_open)
 
     # Image can be uploaded via 'report_media' too.
@@ -37,7 +37,7 @@ def report_debug_images(logger, iteration=0):
         "image",
         "image with report media",
         iteration=iteration,
-        local_path=os.path.join("data_samples", "picasso.jpg"),
+        local_path=os.path.join(os.path.dirname(os.path.abspath(__file__)), "data_samples", "picasso.jpg"),
         file_extension="jpg",
     )
 


### PR DESCRIPTION
Examples points resources using relative paths

## Related Issue \ discussion
No yet

## Patch Description
The example needs to points the folder of the resources in an absolute way.

## Testing Instructions
Execute the examples from a location where the file is not.

## Other Information
