### PR TITLE
fix bad artefact URLs when using Google object storage

### DIFF
--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -527,8 +527,10 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
                 return a_name
             return '{}.{}'.format(a_name[:max(2, max_length-len(uuid)-1)], uuid)
 
+        # workaround for subprojects & Google object storage
+        project_name_safe = self.get_project_name().replace("/", "___")
         return '/'.join(quote(x, safe="'[]{}()$^,.; -_+-=/") for x in
-                        (limit_folder_name(self.get_project_name(), str(self.project), 256, False),
+                        (limit_folder_name(project_name_safe, str(self.project), 256, False),
                          limit_folder_name(self.name, str(self.data.id), 128, True),
                          extra_path) if x)
 


### PR DESCRIPTION
## Related Issue \ discussion
https://github.com/allegroai/clearml/issues/409#issuecomment-1282235811

## Testing Instructions
To reproduce the issue run an experiment within a sub-project and upload an artefact when using Google object storage as a backend.