### PR TITLE
'raise_on_errors' flag exposed to the parameters of Task._delete_arti…

### DIFF
--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -1360,12 +1360,12 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
     def delete_artifacts(self, artifact_names, raise_on_errors):
         # type: (Sequence[str], bool) -> bool
         """
-                Delete a list of artifacts, by artifact name, from the Task.
+        Delete a list of artifacts, by artifact name, from the Task.
 
-                :param list artifact_names: list of artifact names
-                :param bool raise_on_errors: if True, do not suppress connectivity related exceptions
-                :return: True if successful
-                """
+        :param list artifact_names: list of artifact names
+        :param bool raise_on_errors: if True, do not suppress connectivity related exceptions
+        :return: True if successful
+        """
         return self._delete_artifacts(artifact_names, raise_on_errors)
 
     def _delete_artifacts(self, artifact_names, raise_on_errors=False):

--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -1357,12 +1357,24 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
                 self._edit(execution=execution)
         return self.data.execution.artifacts or []
 
-    def _delete_artifacts(self, artifact_names):
-        # type: (Sequence[str]) -> bool
+    def delete_artifacts(self, artifact_names, raise_on_errors):
+        # type: (Sequence[str], bool) -> bool
+        """
+                Delete a list of artifacts, by artifact name, from the Task.
+
+                :param list artifact_names: list of artifact names
+                :param bool raise_on_errors: if True, do not suppress connectivity related exceptions
+                :return: True if successful
+                """
+        return self._delete_artifacts(artifact_names, raise_on_errors)
+
+    def _delete_artifacts(self, artifact_names, raise_on_errors=False):
+        # type: (Sequence[str], bool) -> bool
         """
         Delete a list of artifacts, by artifact name, from the Task.
 
         :param list artifact_names: list of artifact names
+        :param bool raise_on_errors: if True, do not suppress connectivity related exceptions
         :return: True if successful
         """
         if not Session.check_min_api_version('2.3'):
@@ -1374,7 +1386,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
             if Session.check_min_api_version("2.13") and not self._offline_mode:
                 req = tasks.DeleteArtifactsRequest(
                     task=self.task_id, artifacts=[{"key": n, "mode": "output"} for n in artifact_names], force=True)
-                res = self.send(req, raise_on_errors=False)
+                res = self.send(req, raise_on_errors=raise_on_errors)
                 if not res or not res.response or not res.response.deleted:
                     return False
                 self.reload()

--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -1357,7 +1357,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
                 self._edit(execution=execution)
         return self.data.execution.artifacts or []
 
-    def delete_artifacts(self, artifact_names, raise_on_errors):
+    def delete_artifacts(self, artifact_names, raise_on_errors=True):
         # type: (Sequence[str], bool) -> bool
         """
         Delete a list of artifacts, by artifact name, from the Task.


### PR DESCRIPTION
Avoids infinite loop in case of problems with the connection to the API server.

## Related Issue \ discussion
[805](https://github.com/allegroai/clearml/issues/805#issue-1420255351)

## Patch Description
If the flag `raise_on_errors` is set to True, in case of connectivity problems, it's possible to catch the exception and avoid an infinite loop of retries

## Testing Instructions
1. Initiate a task
2. Upload an artifact to it
3. Simulate a connection break
4. Execute `task.delete_artifacts()`
5. Catch the `requests.exceptions.ConnectTimeout`
Result: the main thread doesn't freeze

## Other Information
In order not to use a private function externally, a public version added as well.