### PR TITLE
dataset compression bug fix

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -686,7 +686,7 @@ class Dataset(object):
                 chunk_size,
                 max_workers,
                 allow_zip_64=True,
-                compression=compression or ZIP_DEFLATED,
+                compression=ZIP_DEFLATED if compression is None else compression,
                 zip_prefix="dataset.{}.".format(self._id),
                 zip_suffix=".zip",
                 verbose=verbose,


### PR DESCRIPTION
## Related Issue \ discussion
[Slack thread](https://app.slack.com/client/TT9ATQXJ5/CTK20V944/thread/CTK20V944-1666866226.167449)

## Patch Description
Fixed a bug where passing compression=ZIP_STORED (or 0) to Dataset.upload() uses ZIP_DEFLATED despite the user-supplied argument

## Testing Instructions
upload any dataset and check if the resulting artifact is zip compressed or not.

## Other Information
