### PR TITLE
Fix for dataset not getting synced when there are only modified files

### DIFF
--- a/clearml/cli/data/__main__.py
+++ b/clearml/cli/data/__main__.py
@@ -667,7 +667,7 @@ def ds_sync(args):
     print("Sync completed: {} files removed, {} added, {} modified".format(removed, added, modified))
 
     if not args.skip_close:
-        if dataset_created and not removed and not added:
+        if dataset_created and not removed and not added and not modified:
             print('Zero modifications on local copy, reverting dataset creation.')
             Dataset.delete(ds.id, force=True)
             return 0


### PR DESCRIPTION
## Related Issue \ discussion
See allegroai/clearml#822

## Patch Description
Use the number of modified files along with the number of added and removed file in the check that determines whether to proceed or not with the sync operation.

## Testing Instructions
Create a new version of a dataset by syncing with only modified files (no added and no removed files, just modified files).

## Other Information
