### PR TITLE
Added r prefix to re.match strings

### DIFF
--- a/clearml/backend_api/session/jsonmodels/fields.py
+++ b/clearml/backend_api/session/jsonmodels/fields.py
@@ -134,7 +134,7 @@ class BaseField(object):
     def _validate_name(self):
         if self.name is None:
             return
-        if not re.match('^[A-Za-z_](([\w\-]*)?\w+)?$', self.name):  # noqa: W605
+        if not re.match(r'^[A-Za-z_](([\w\-]*)?\w+)?$', self.name):  # noqa: W605
             raise ValueError('Wrong name', self.name)
 
     def structue_name(self, default):

--- a/clearml/utilities/pyhocon/config_tree.py
+++ b/clearml/utilities/pyhocon/config_tree.py
@@ -338,7 +338,7 @@ class ConfigTree(OrderedDict):
         elif isinstance(value, ConfigTree):
             lst = []
             for k, v in sorted(value.items(), key=lambda kv: kv[0]):
-                if re.match('^[1-9][0-9]*$|0', k):
+                if re.match(r'^[1-9][0-9]*$|0', k):
                     lst.append(v)
                 else:
                     raise ConfigException(u"{key} does not translate to a list".format(key=key))


### PR DESCRIPTION
## Related Issue \ discussion
https://github.com/allegroai/clearml/issues/834

## Patch Description
Avoiding `DeprecationWarning: invalid escape sequence \w` by ensuring all `re.match` strings are prefixed with `r` (raw string)

## Testing Instructions
Very minor fix

## Other Information
None