### PR TITLE
Make StorageHelper.get_object() call StorageHelper._canonized_url()

### DIFF
--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -1193,6 +1193,7 @@ class StorageHelper(object):
 
         :return: The remote object
         """
+        path = self._canonize_url(path)
         object_name = self._normalize_object_name(path)
         try:
             return self._driver.get_object(


### PR DESCRIPTION
## Related Issue \ discussion
Fixes allegroai/clearml#825

## Patch Description
Adds a call to `StorageHelper._canonize_url(path)` in the `StorageHelper.get_object(...)` function.
This enables `StorageHelper.delete(...)` and other functions using `StorageHelper.get_object(...)` to respect the path substitutions configured.

## Testing Instructions
Configure a path substitution where the path before substitution is not accessible.
Calls to `StorageHelper.delete(...)` and `StorageHelper.check_write_permissions(...)` (which calls `delete(...)`) should still succeed