### PR TITLE
Exception in case of a connection break propagated to the upper level instead of being suppressed in an infinite loop

### DIFF
--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -1438,7 +1438,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
         with self._edit_lock:
             if Session.check_min_api_version("2.13") and not self._offline_mode:
                 req = tasks.AddOrUpdateArtifactsRequest(task=self.task_id, artifacts=artifacts_list, force=True)
-                res = self.send(req, raise_on_errors=False)
+                res = self.send(req, raise_on_errors=True)
                 if not res or not res.response or not res.response.updated:
                     return None
                 self.reload()
@@ -2317,7 +2317,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
                         "[status={} fields={}]".format(status, list(kwargs.keys()))
                     )
 
-            res = self.send(tasks.EditRequest(task=self.id, force=True, **kwargs), raise_on_errors=False)
+            res = self.send(tasks.EditRequest(task=self.id, force=True, **kwargs), raise_on_errors=True)
             return res
 
     def _update_requirements(self, requirements):


### PR DESCRIPTION
Avoids infinite loop in case of problems with the connection to the API server. The PR is similar to [another one](https://github.com/allegroai/clearml/pull/806) related to connectivity problems

## Related Issue \ discussion
#852 <br/>

## Patch Description
If the flag `raise_on_errors` is set to True, in case of connectivity problems, it's possible to catch the exception and avoid an infinite loop of retries<br/>

## Testing Instructions
1. Initiate a task
2. Simulate a connection break
3. Upload an artifact to the task, or set a parameter to it
4. Catch the `requests.exceptions.ConnectionError`
5. Result: the main thread doesn't freeze 

## Other information  
There's another way to avoid the main thread freezing - make the code which updates tasks asynchronous. Anyway, with an infinite loop taking place there's little sense in stacking task update jobs which will potentially never finish.