### PR TITLE
Bugfix for storage with path substitutions

### DIFF
--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -781,7 +781,7 @@ class StorageHelper(object):
             Listed relative to the base path.
         """
         if prefix:
-            prefix = self._canonize_url(dest_path)
+            prefix = self._canonize_url(prefix)
             if prefix.startswith(self._base_url):
                 prefix = prefix[len(self._base_url):]
                 if self._base_url != "file://":

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -619,7 +619,7 @@ class StorageHelper(object):
             if isinstance(self._driver, _HttpDriver) and obj:
                 obj = self._driver._get_download_object(obj)  # noqa
                 size = int(obj.headers.get("Content-Length", 0))
-            elif isinstance(self._driver, _Boto3Driver) and obj:
+            elif isinstance(self._driver, _Boto3Driver) and obj and hasattr(obj, "content_length"):
                 # noinspection PyBroadException
                 try:
                     # To catch botocore exceptions
@@ -781,6 +781,7 @@ class StorageHelper(object):
             Listed relative to the base path.
         """
         if prefix:
+            prefix = self._canonize_url(dest_path)
             if prefix.startswith(self._base_url):
                 prefix = prefix[len(self._base_url):]
                 if self._base_url != "file://":

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -1237,6 +1237,7 @@ class StorageHelper(object):
                 pass
 
     def exists_file(self, remote_url):
+        remote_url = self._canonize_url(remote_url)
         object_name = self._normalize_object_name(remote_url)
         return self._driver.exists_file(
             container_name=self._container.name if self._container else "", object_name=object_name

--- a/clearml/storage/manager.py
+++ b/clearml/storage/manager.py
@@ -481,8 +481,9 @@ class StorageManager(object):
         if not obj:
             return None
         metadata = helper.get_object_metadata(obj)
-        if return_full_path and not metadata["name"].startswith(helper.base_url):
-            metadata["name"] = helper.base_url + ("/" if not helper.base_url.endswith("/") else "") + metadata["name"]
+        base_url = helper._resolve_base_url(remote_url)
+        if return_full_path and not metadata["name"].startswith(base_url):
+            metadata["name"] = base_url + ("/" if not base_url.endswith("/") else "") + metadata["name"]
         return metadata
 
     @classmethod


### PR DESCRIPTION
## Related Issue \ discussion
Related to [this previous issue](https://github.com/allegroai/clearml/issues/825), I noticed a few more problems when using path substitutions together with datasets.

## Patch Description
The patch makes both StorageHelper.list() and StorageHelper.exists_file() respect the path substitutions that are set up.

It also makes _get_object_size_bytes only use a special case for the boto driver if the result has the content_length attribute (therefore it is a boto s3 object), as the ListResult that will still occur in combination with the Boto3Driver only has the size attribute.

Finally it handles a problem where the get_metadata of the storage_manager will return the url for the objects with the canonized base url(i.e. with the local path substitutions applied), instead of the original remote_url. There might be a better way to fix this last issue, so suggestions are welcome.