### PR TITLE
Add signature version to boto3 config

### DIFF
--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -1523,6 +1523,7 @@ class _Boto3Driver(_Driver):
     _pool_connections = deferred_config('aws.boto3.pool_connections', 512)
     _connect_timeout = deferred_config('aws.boto3.connect_timeout', 60)
     _read_timeout = deferred_config('aws.boto3.read_timeout', 60)
+    _signature_version = deferred_config('aws.boto3.signature_version', None)
 
     _stream_download_pool_connections = deferred_config('aws.boto3.stream_connections', 128)
     _stream_download_pool = None
@@ -1566,6 +1567,7 @@ class _Boto3Driver(_Driver):
                             int(_Boto3Driver._pool_connections)),
                         connect_timeout=int(_Boto3Driver._connect_timeout),
                         read_timeout=int(_Boto3Driver._read_timeout),
+                        signature_version=_Boto3Driver._signature_version,
                     )
                 }
                 if not cfg.use_credentials_chain:


### PR DESCRIPTION
## Related Issue \ discussion
[Issue Link](https://github.com/allegroai/clearml/issues/883)

## Patch Description
I added a `signature_version` entry to the boto3 section of the s3 configuration. This allows a user to specify the signature version for their s3 storage backend.

## Testing Instructions
Push artifacts through clearml to an s3 service with an older signature version, specifying the correct signature version in the clearml config.

## Other Information
