### PR TITLE
Add extra split identifier

### DIFF
--- a/clearml/backend_interface/task/populate.py
+++ b/clearml/backend_interface/task/populate.py
@@ -255,7 +255,7 @@ class CreateAndPopulate(object):
             for line in reqs:
                 if line.strip().startswith('#'):
                     continue
-                package = reduce(lambda a, b: a.split(b)[0], "#;@=~<>", line).strip()
+                package = reduce(lambda a, b: a.split(b)[0], "#;@=~<>[", line).strip()
                 if package == 'clearml':
                     clearml_found = True
                     break


### PR DESCRIPTION
Fix a bug that if `clearml` is specified as requirement with extras (e.g. `clearml[azure]`) it would not be identified as clearml when creating a new Task.

## Related Issue \ discussion
https://github.com/allegroai/clearml/issues/867

## Patch Description
In the method that processes all specified requirements and looking for whether `clearml` package was included, added an extra split identifier to ensure to make sure presence of "extras" (i.e. `[...]`) does not influence determining whether `clearml` is included in requirements.

## Testing Instructions
Create a Task with requirements or packages, and include a version of clearml with extras. Make sure `clearml` is not appended to list of requirements.