### PR TITLE
Remove `exit_process` restriction on `execute_remotely`

### DIFF
--- a/clearml/task.py
+++ b/clearml/task.py
@@ -2477,10 +2477,6 @@ class Task(_Task):
             - ``True`` - Exit the process (exit(0)).
             - ``False`` - Do not exit the process.
 
-            .. warning::
-
-                If ``clone==False``, then ``exit_process`` must be ``True``.
-
         :return Task: return the task object of the newly generated remotely executing task
         """
         # do nothing, we are running remotely
@@ -2497,11 +2493,6 @@ class Task(_Task):
             enqueue_task = Task.clone(source_task=self) if clone else self
             Task.enqueue(task=enqueue_task, queue_name=queue_name)
             return
-
-        if not clone and not exit_process:
-            raise ValueError(
-                "clone==False and exit_process==False is not supported. "
-                "Task enqueuing itself must exit the process afterwards.")
 
         # make sure we analyze the process
         if self.status in (Task.TaskStatusEnum.in_progress,):


### PR DESCRIPTION
## Related Issue \ discussion
[Slack discussion](https://clearml.slack.com/archives/CTK20V944/p1673286661348369).

## Patch Description
This change removes a restriction that I don't think is required (would love to know whether this is correct or not!) and blocks my proposed workflow. 

The workflow I want to do is:

1. Create a `task` using `Task.init`
2. Configure the `task`
3. Call `task.execute_remotely()` so that the `task` is reset to `pending` in the server
4. Back to step 1 (without exiting the python process)
