### PR TITLE
updated logger.report_confusion_matrix.py

### DIFF
--- a/clearml/logger.py
+++ b/clearml/logger.py
@@ -617,7 +617,6 @@ class Logger(object):
     def report_confusion_matrix(
             self,
             title,  # type: str
-            series,  # type: str
             matrix,  # type: np.ndarray
             iteration=None,  # type: Optional[int]
             xaxis=None,  # type: Optional[str]
@@ -626,7 +625,7 @@ class Logger(object):
             ylabels=None,  # type: Optional[List[str]]
             yaxis_reversed=False,  # type: bool
             comment=None,  # type: Optional[str]
-            extra_layout=None,  # type: Optional[dict]
+            extra_layout={'texttemplate': '%{z}'},  # type: Optional[dict]
     ):
         """
         For explicit reporting, plot a heat-map matrix.
@@ -636,11 +635,10 @@ class Logger(object):
         .. code-block:: py
 
            confusion = np.random.randint(10, size=(10, 10))
-           logger.report_confusion_matrix("example confusion matrix", "ignored", iteration=1, matrix=confusion,
+           logger.report_confusion_matrix("example confusion matrix", iteration=1, matrix=confusion,
                 xaxis="title X", yaxis="title Y")
 
         :param str title: The title (metric) of the plot.
-        :param str series: The series name (variant) of the reported confusion matrix.
         :param numpy.ndarray matrix: A heat-map matrix (example: confusion matrix)
         :param int iteration: The reported iteration / step.
         :param str xaxis: The x-axis title. (Optional)
@@ -663,7 +661,7 @@ class Logger(object):
         # noinspection PyProtectedMember
         return self._task._reporter.report_value_matrix(
             title=title,
-            series=series,
+            series='ignored',
             data=matrix.astype(np.float32),
             iter=iteration or 0,
             xtitle=xaxis,


### PR DESCRIPTION
* set annotated cells (cells with text inside them) to be the default.
* removed the unused series argument from the signature.

## Related Issue \ discussion
If this patch originated from a github issue or slack conversation, please paste a link to the original discussion<br/>

## Patch Description
Description of what does the patch do. If the patch solves a bug, explain what the bug is and how to reproduce it 
(If not already mentioned in the original conversation)<br/>

## Testing Instructions
Instructions of how to test the patch or reproduce the issue the patch is aiming to solve

## Other Information
