### PR TITLE
jupyter api token patch

### DIFF
--- a/clearml/backend_interface/task/repo/scriptinfo.py
+++ b/clearml/backend_interface/task/repo/scriptinfo.py
@@ -649,7 +649,8 @@ class ScriptInfo(object):
                                       data={'_xsrf': cookies['_xsrf'], 'password': password})
                     cookies.update(r.cookies)
 
-                auth_token = server_info.get('token') or os.getenv('JUPYTERHUB_API_TOKEN') or ''
+                # get api token from ENV - if not defined then from server info
+                auth_token = os.getenv('JUPYTERHUB_API_TOKEN') or server_info.get('token') or ''
                 try:
                     r = requests.get(
                         url=server_info['url'] + 'api/sessions', cookies=cookies,


### PR DESCRIPTION
## Related Issue \ discussion
If this patch originated from a github issue or slack conversation, please paste a link to the original discussion<br/>

## Patch Description
This patch aims to solve an issue with newer versions of JupyterLab Notebook containing the wrong API key inside of `jpserver-x.json` while the environment variable `JUPYTERHUB_API_TOKEN` contains the correct one.<br/>

## Testing Instructions
Create a JupyterLab version 3.5.2
run a ClearML task while storing Jupyter Notebook as code instead of a remote git repository
`clearml.Repository Detection - WARNING - Failed accessing the jupyter server: 403 Client Error: Forbidden for url: http://jupyter:888/user/me/api/sessions`

## Other Information
