### PR TITLE
Fixed bug in `report_confusion_matrix` when `series` argument was removed

### DIFF
--- a/clearml/logger.py
+++ b/clearml/logger.py
@@ -651,7 +651,6 @@ class Logger(object):
 
         # if task was not started, we have to start it
         self._start_task_if_needed()
-        self._touch_title_series(title, series)
         # noinspection PyProtectedMember
         return self._task._reporter.report_value_matrix(
             title=title,


### PR DESCRIPTION
Description:

`series` argument was removed but `self._touch_title_series(title, series)` was kept and it produces the error:
```
File "/opt/conda/lib/python3.9/site-packages/clearml/logger.py", line 654, in report_confusion_matrix self._touch_title_series(title, series) NameError: name 'series' is not defined
```


Related commit:
- https://github.com/allegroai/clearml/commit/da6f75363db8c9d1ad2032ab075916e409b1170f#r102003686