### PR TITLE
Add "output_uri=True" in the hook config (openmmlab example)

### DIFF
--- a/examples/frameworks/openmmlab/openmmlab_cifar10.py
+++ b/examples/frameworks/openmmlab/openmmlab_cifar10.py
@@ -79,7 +79,8 @@ if __name__ == '__main__':
                 type='ClearMLLoggerHook',
                 init_kwargs=dict(
                     project_name='examples',
-                    task_name='OpenMMLab cifar10'
+                    task_name='OpenMMLab cifar10',
+                    output_uri=True
                 )
             ),
         ]


### PR DESCRIPTION
When "output_uri" is set to True, it uploads the Artifacts or Models to the ClearML Server.