### PR TITLE
Bugfix for issue 946: git pip install invalid

### DIFF
--- a/clearml/utilities/pigar/reqs.py
+++ b/clearml/utilities/pigar/reqs.py
@@ -409,9 +409,10 @@ def _search_path(path):
                         direct_json = json.load(f)
 
                     if 'vcs_info' in direct_json:
+                        vcs_info = direct_json['vcs_info']
                         git_url = '{vcs}+{url}@{commit}#egg={package}'.format(
-                            vcs=direct_json['vcs_info']['vcs'], url=direct_json['url'],
-                            commit=direct_json['vcs_info']['commit_id'], package=pkg_name)
+                            vcs=vcs_info['vcs'], url=direct_json['url'],
+                            commit=vcs_info['commit_id'], package=pkg_name)
                         # If subdirectory is present, append this to the git_url
                         if 'subdirectory' in direct_json:
                             git_url = '{git_url}&subdirectory={subdirectory}'.format(

--- a/clearml/utilities/pigar/reqs.py
+++ b/clearml/utilities/pigar/reqs.py
@@ -406,19 +406,27 @@ def _search_path(path):
                 # noinspection PyBroadException
                 try:
                     with open(git_direct_json, 'r') as f:
-                        vcs_info = json.load(f)
+                        direct_json = json.load(f)
 
-                    if 'vcs_info' in vcs_info:
+                    if 'vcs_info' in direct_json:
                         git_url = '{vcs}+{url}@{commit}#egg={package}'.format(
-                            vcs=vcs_info['vcs_info']['vcs'], url=vcs_info['url'],
-                            commit=vcs_info['vcs_info']['commit_id'], package=pkg_name)
+                            vcs=direct_json['vcs_info']['vcs'], url=direct_json['url'],
+                            commit=direct_json['vcs_info']['commit_id'], package=pkg_name)
                         # Bugfix: package name should be the URL link, because we need it unique
                         # mapping[pkg_name] = ('-e', git_url)
+                        if 'subdirectory' in direct_json:
+                            git_url = '{git_url}&subdirectory={subdirectory}'.format(
+                                git_url=git_url, subdirectory=direct_json['subdirectory'])
                         pkg_name, version = '-e {}'.format(git_url), ''
-                    elif 'url' in vcs_info:
-                        url_link = vcs_info.get('url', '').strip().lower()
+                    elif 'url' in direct_json:
+                        url_link = direct_json.get('url', '').strip().lower()
                         if url_link and not url_link.startswith('file://'):
-                            pkg_name, version = vcs_info['url'], ''
+                            git_url = direct_json['url']
+                            if 'subdirectory' in direct_json:
+                                git_url = '{git_url}#subdirectory={subdirectory}'.format(
+                                    git_url=direct_json['url'], subdirectory=direct_json['subdirectory'])
+
+                            pkg_name, version = git_url, ''
 
                 except Exception:
                     pass

--- a/clearml/utilities/pigar/reqs.py
+++ b/clearml/utilities/pigar/reqs.py
@@ -412,16 +412,18 @@ def _search_path(path):
                         git_url = '{vcs}+{url}@{commit}#egg={package}'.format(
                             vcs=direct_json['vcs_info']['vcs'], url=direct_json['url'],
                             commit=direct_json['vcs_info']['commit_id'], package=pkg_name)
-                        # Bugfix: package name should be the URL link, because we need it unique
-                        # mapping[pkg_name] = ('-e', git_url)
+                        # If subdirectory is present, append this to the git_url
                         if 'subdirectory' in direct_json:
                             git_url = '{git_url}&subdirectory={subdirectory}'.format(
                                 git_url=git_url, subdirectory=direct_json['subdirectory'])
+                        # Bugfix: package name should be the URL link, because we need it unique
+                        # mapping[pkg_name] = ('-e', git_url)
                         pkg_name, version = '-e {}'.format(git_url), ''
                     elif 'url' in direct_json:
                         url_link = direct_json.get('url', '').strip().lower()
                         if url_link and not url_link.startswith('file://'):
                             git_url = direct_json['url']
+                            # If subdirectory is present, append this to the git_url
                             if 'subdirectory' in direct_json:
                                 git_url = '{git_url}#subdirectory={subdirectory}'.format(
                                     git_url=direct_json['url'], subdirectory=direct_json['subdirectory'])


### PR DESCRIPTION
Modified logic which parses github dependencies to include subdirectory functionality

## Related Issue \ discussion
If this patch originated from a github issue or slack conversation, please paste a link to the original discussion<br/>
https://github.com/allegroai/clearml/issues/946

## Patch Description
Description of what does the patch do. If the patch solves a bug, explain what the bug is and how to reproduce it 
(If not already mentioned in the original conversation)<br/>

Patch adds github subdirectory to path.

## Testing Instructions
Instructions of how to test the patch or reproduce the issue the patch is aiming to solve

See Issue https://github.com/allegroai/clearml/issues/946. I have tested this locally and I believe it fixes the issue.

## Other Information
