### PR TITLE
External files: Improve performance

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -460,7 +460,7 @@ class Dataset(object):
         source_url_list = source_url if not isinstance(source_url, str) else [source_url]
         max_workers = max_workers or psutil.cpu_count()
         futures_ = []
-        if isinstance(dataset_path,str) or dataset_path is None:
+        if isinstance(dataset_path, str) or dataset_path is None:
             dataset_paths = itertools.repeat(dataset_path)
         else:
             if len(dataset_path) != len(source_url):

--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -460,7 +460,7 @@ class Dataset(object):
         source_url_list = source_url if not isinstance(source_url, str) else [source_url]
         max_workers = max_workers or psutil.cpu_count()
         futures_ = []
-        if isinstance(dataset_path,str):
+        if isinstance(dataset_path,str) or dataset_path is None:
             dataset_paths = itertools.repeat(dataset_path)
         else:
             if len(dataset_path) != len(source_url):

--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -2258,7 +2258,7 @@ class Dataset(object):
                 LoggerRoot.get_base_logger().info(log_string)
             else:
                 link.size = Path(target_path).stat().st_size
-        if max_workers is None or max_workers == 0:
+        if not max_workers:
             for relative_path, link in links.items():
                 target_path = os.path.join(target_folder, relative_path)
                 _download_link(link,target_path)


### PR DESCRIPTION
Add option for faster .add_external_files() option
Add option for parallel external file download

add_external_files: Add the option for specifying one dataset_path per entry in source_url. This was multiple files with different dataset_paths can be added in one batch, otherwise the update of the dataset state introduces a huge overhead for large number of files with different dataset paths

Parameter max_workers_external_files: Allow a parallel download of external files (especially relevant for smaller files). For backwards compatibility, this is introduced as a new parameter. It could just use the value of the existing parameter if desired. I am not sure how the internal threadpool of the boto library plays together with this in the case of larger files. 


## Related Issue \ discussion
If this patch originated from a github issue or slack conversation, please paste a link to the original discussion<br/>

## Patch Description
This PR adds a few options to allow for faster download of external files as well as for faster adding of external files to the dataset.


## Testing Instructions
Instructions of how to test the patch or reproduce the issue the patch is aiming to solve

## Other Information
