### PR TITLE
Fix repo_root path for windows coming from vcs

### DIFF
--- a/clearml/backend_interface/task/repo/scriptinfo.py
+++ b/clearml/backend_interface/task/repo/scriptinfo.py
@@ -831,6 +831,10 @@ class ScriptInfo(object):
         repo_root = Path(repo_root).absolute()
         script_path = Path(script_path)
 
+        if os.name == "nt" and repo_root[0] == "/":  # Windows and path repo_root has following form /c/...
+            drive = repo_root[1]
+            repo_root = repo_root.replace(f"/{drive}/", f"{drive}:/")
+
         try:
             # Use os.path.relpath as it calculates up dir movements (../)
             entry_point = os.path.relpath(


### PR DESCRIPTION
## Patch Description
Detect if running on windows and path starts with forward slash. In that case replace `/c/` by `c:/`.

## Testing Instructions
Code to reproduce the issue originating from the VCS `repo_root`:
```python
import os
from pathlib import Path

script_path = Path(r"D:\dev\clearml\clearml\test.py")
repo_root = "/d/dev/clearml"

# Fix start
# if os.name == "nt" and repo_root[0] == "/":
#     drive = repo_root[1]
#     repo_root = repo_root.replace(f"/{drive}/", f"{drive}:/")
# Fix end

repo_root = Path(repo_root).absolute()
entry_point = os.path.relpath(
    str(os.path.realpath(script_path.as_posix())),
    str(repo_root))

print(f"Path is {entry_point}")
print(r"Path should be clearml\test.py")
```
@john-zielke-snkeos 