### PR TITLE
Fix comment for storage scheme gs://

### DIFF
--- a/clearml/logger.py
+++ b/clearml/logger.py
@@ -1067,7 +1067,7 @@ class Logger(object):
 
         :param str uri: example: 's3://bucket/directory/' or 'file:///tmp/debug/'
 
-        :return: True, if the destination scheme is supported (for example, ``s3://``, ``file://``, or ``gc://``).
+        :return: True, if the destination scheme is supported (for example, ``s3://``, ``file://``, or ``gs://``).
             False, if not supported.
 
         """


### PR DESCRIPTION
## Related Issue \ discussion
Fixed typo in the Logger documentation... Google's GCS protocol is gs:// not gc://
- Issue: https://github.com/allegroai/clearml/issues/986

## Patch Description
Changed protocol in doc comment to `gs://`

## Testing Instructions
See: https://clear.ml/docs/latest/docs/references/sdk/logger/#set_default_upload_destination

## Other Information
n/a