### PR TITLE
fix config parsing for the case of empty string keys

### DIFF
--- a/clearml/utilities/pyhocon/config_tree.py
+++ b/clearml/utilities/pyhocon/config_tree.py
@@ -186,7 +186,7 @@ class ConfigTree(OrderedDict):
 
         special_characters = '$}[]:=+#`^?!@*&.'
         tokens = re.findall(
-            r'"[^"]+"|[^{special_characters}]+'.format(special_characters=re.escape(special_characters)),
+            r'"[^"]+"|[^{special_characters}]+|^$'.format(special_characters=re.escape(special_characters)),
             string)
 
         def contains_special_character(token):


### PR DESCRIPTION
## Patch Description

Solves this bug: 
```python
from clearml.utilities.pyhocon.config_parser import ConfigFactory
ConfigFactory.from_dict({"": 1})
```
fails with `IndexError: list index out of range`.