### PR TITLE
Fix typo "Categories per column"

### DIFF
--- a/examples/frameworks/pytorch/notebooks/table/train_tabular_predictor.ipynb
+++ b/examples/frameworks/pytorch/notebooks/table/train_tabular_predictor.ipynb
@@ -109,7 +109,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "columns_categories = data_task.artifacts[\"Categries per column\"].get()\n",
+    "columns_categories = data_task.artifacts[\"Categories per column\"].get()\n",
     "columns_categories_ordered = {\n",
     "    key: columns_categories[key]\n",
     "    for key in train_set.columns\n",


### PR DESCRIPTION
## Related Issue \ discussion
Example in jupyter notebook dont work correctly

## Patch Description
Fix typo in artifacts name
