### PR TITLE
Handle web app on standard HTTP and HTTPS port

### DIFF
--- a/clearml/cli/config/__main__.py
+++ b/clearml/cli/config/__main__.py
@@ -237,6 +237,12 @@ def parse_known_host(parsed_host):
         api_host = parsed_host.scheme + "://" + parsed_host.netloc.replace(':8080', ':8008', 1) + parsed_host.path
         web_host = parsed_host.scheme + "://" + parsed_host.netloc + parsed_host.path
         files_host = parsed_host.scheme + "://" + parsed_host.netloc.replace(':8080', ':8081', 1) + parsed_host.path
+    elif parsed_host.port is None:
+        print('Web app hosted on standard port using ' + parsed_host.scheme + ' protocol.')
+        print('Assuming files and api ports are unchanged and use the same (' + parsed_host.scheme + ') protocol')
+        api_host = parsed_host.scheme + "://" + parsed_host.netloc + ':8008' + parsed_host.path
+        web_host = parsed_host.scheme + "://" + parsed_host.netloc + parsed_host.path
+        files_host = parsed_host.scheme + "://" + parsed_host.netloc+ ':8081' + parsed_host.path
     else:
         print("Warning! Could not parse host name")
         api_host = ''


### PR DESCRIPTION
Closes: https://github.com/allegroai/clearml-server/issues/198

It would handle configurations when web app port is changed to a standard port for HTTP or HTTPS.

It allows configurations like:

    web_server: http://clearml.xyz.local
    api_server: http://clearml.xyz.local:8008
    file_server: http://clearml.xyz.local:8081/
