### PR TITLE
Fix typo in projects docstring

### DIFF
--- a/clearml/backend_api/services/v2_20/projects.py
+++ b/clearml/backend_api/services/v2_20/projects.py
@@ -4590,7 +4590,7 @@ class UpdateResponse(Response):
 
 class ValidateDeleteRequest(Request):
     """
-    Validates that the project existis and can be deleted
+    Validates that the project exists and can be deleted
 
     :param project: Project ID
     :type project: str

--- a/clearml/backend_api/services/v2_23/projects.py
+++ b/clearml/backend_api/services/v2_23/projects.py
@@ -4616,7 +4616,7 @@ class UpdateResponse(Response):
 
 class ValidateDeleteRequest(Request):
     """
-    Validates that the project existis and can be deleted
+    Validates that the project exists and can be deleted
 
     :param project: Project ID
     :type project: str


### PR DESCRIPTION
## Patch Description
Fixes typo in projects docstring `existis -> exists`<br/>
