### PR TITLE
Added `include archive` to optionally exclude archived datasets from dataset.list datasets()

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -122,7 +122,7 @@ class Dataset(object):
     __hyperparams_section = "Datasets"
     __datasets_runtime_prop = "datasets"
     __orig_datasets_runtime_prop_prefix = "orig_datasets"
-    __preview_media_max_file_size =  deferred_config("dataset.preview.media.max_file_size", 5 * 1024 * 1024, transform=int)
+    __preview_media_max_file_size = deferred_config("dataset.preview.media.max_file_size", 5 * 1024 * 1024, transform=int)
     __preview_tabular_table_count = deferred_config("dataset.preview.tabular.table_count", 10, transform=int)
     __preview_tabular_row_count = deferred_config("dataset.preview.tabular.row_count", 10, transform=int)
     __preview_media_image_count = deferred_config("dataset.preview.media.image_count", 10, transform=int)
@@ -2287,14 +2287,15 @@ class Dataset(object):
             ds = Dataset.get(dependency)
             links.update(ds._dataset_link_entries)
         links.update(self._dataset_link_entries)
-        def _download_link(link,target_path):
+
+        def _download_link(link, target_path):
             if os.path.exists(target_path):
-                    LoggerRoot.get_base_logger().info(
-                        "{} already exists. Skipping downloading {}".format(
-                            target_path, link
-                        )
+                LoggerRoot.get_base_logger().info(
+                    "{} already exists. Skipping downloading {}".format(
+                        target_path, link
                     )
-                    return
+                )
+                return
             ok = False
             error = None
             try:
@@ -2319,16 +2320,12 @@ class Dataset(object):
         if not max_workers:
             for relative_path, link in links.items():
                 target_path = os.path.join(target_folder, relative_path)
-                _download_link(link,target_path)
+                _download_link(link, target_path)
         else:
             with ThreadPoolExecutor(max_workers=max_workers) as pool:
                 for relative_path, link in links.items():
                     target_path = os.path.join(target_folder, relative_path)
-                    pool.submit(_download_link,link,target_path)
-
-
-
-
+                    pool.submit(_download_link, link, target_path)
 
     def _extract_dataset_archive(
             self,
@@ -2729,7 +2726,7 @@ class Dataset(object):
             dataset._task.mark_completed()
 
         return id
-    
+
     def _log_dataset_page(self):
         if bool(Session.check_min_api_server_version(self.__min_api_version)):
             self._task.get_logger().report_text(
@@ -2741,6 +2738,7 @@ class Dataset(object):
                     )
                 )
             )
+
     def _build_dependency_chunk_lookup(self):
         # type: () -> Dict[str, int]
         """


### PR DESCRIPTION
## Related Issue \ discussion
Related issue:
https://github.com/allegroai/clearml/issues/1067

## Patch Description
* Added the option include_archived to Dataset.list_datasets() class method which, if False, will exclude archived datasets from the list. Defaults to True to maintain the current behavior of the class method. While it's possible to filter datasets using the get() class method it wasn't possible to do the same for the list_datasets() method. This feature seems useful to include and it's a simple, non-breaking modification.

* Updated formatting (whitespaces/spaces after comma/line breaks) in accordance with the flake8 formatting checks for dataset.py. As suggested in the contribution guidelines, fake8 was used to validate the formatting. Several errors were found from prior commits that were fixed.

## Testing Instructions
Dataset.list_datasets(..., include_archived=False) shouldn't include archived datasets in the list.