### PR TITLE
Fix dataset.list dataset() partial match fix for special chars

### DIFF
--- a/clearml/task.py
+++ b/clearml/task.py
@@ -9,8 +9,10 @@ import threading
 import time
 from argparse import ArgumentParser
 from logging import getLogger
+from re import escape
 from tempfile import mkstemp, mkdtemp
 from zipfile import ZipFile, ZIP_DEFLATED
+
 
 try:
     # noinspection PyCompatibility
@@ -4429,7 +4431,7 @@ class Task(_Task):
             request_kwargs = dict(
                 id=task_ids,
                 project=project_ids if project_ids else kwargs.pop("project", None),
-                name=task_name if task_name else kwargs.pop("name", None),
+                name=escape(task_name) if task_name else kwargs.pop("name", None),
                 only_fields=only_fields,
                 page=page,
                 page_size=page_size,

--- a/clearml/task.py
+++ b/clearml/task.py
@@ -4425,13 +4425,14 @@ class Task(_Task):
         ret_tasks = []
         page = -1
         page_size = 500
+        request_task_name = task_name if task_name else kwargs.pop("name", None)
         while page == -1 or (not fetch_only_first_page and res and len(res.response.tasks) == page_size):
             page += 1
             # work on a copy and make sure we override all fields with ours
             request_kwargs = dict(
                 id=task_ids,
                 project=project_ids if project_ids else kwargs.pop("project", None),
-                name=escape(task_name) if task_name else kwargs.pop("name", None),
+                name=escape(request_task_name) if request_task_name else request_task_name,
                 only_fields=only_fields,
                 page=page,
                 page_size=page_size,


### PR DESCRIPTION
## Related Issue \ discussion
https://github.com/allegroai/clearml/issues/1076

## Patch Description
This patch fixes Task._query_task() by escaping the task_name attribute passed to the function. Without this, task_names passed with special characters would break the search. 

## Testing Instructions
See: https://github.com/allegroai/clearml/issues/1076