### PR TITLE
raise error if dataset name empty.

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -232,6 +232,9 @@ class Dataset(object):
             if dataset_tags:
                 task.set_tags((task.get_tags() or []) + list(dataset_tags))
             task.mark_started()
+            if dataset_name == "":
+                raise ValueError("An empty string for a dataset name will cause the dataset's project to be hidden.")
+
             if not Dataset.is_offline():
                 # generate the script section
                 script = (

--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -159,6 +159,8 @@ class Dataset(object):
                 LoggerRoot.get_base_logger().warning(
                     "Setting non-semantic dataset version '{}'".format(self._dataset_version)
                 )
+        if dataset_name == "":
+            raise ValueError("`dataset_name` cannot be an empty string")
         if task:
             self._task_pinger = None
             self._created_task = False
@@ -232,8 +234,6 @@ class Dataset(object):
             if dataset_tags:
                 task.set_tags((task.get_tags() or []) + list(dataset_tags))
             task.mark_started()
-            if dataset_name == "":
-                raise ValueError("An empty string for a dataset name will cause the dataset's project to be hidden.")
 
             if not Dataset.is_offline():
                 # generate the script section

--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -234,7 +234,6 @@ class Dataset(object):
             if dataset_tags:
                 task.set_tags((task.get_tags() or []) + list(dataset_tags))
             task.mark_started()
-
             if not Dataset.is_offline():
                 # generate the script section
                 script = (


### PR DESCRIPTION
Addresses behavior of the project of a dataset being hidden when dataset name is an empty string.

If the dataset project happens to match an existing project, it can be quite jarring to have one's history of experiments suddenly become hidden / make one think they "disappeared" (shown when hidden files enabled in UI, but new tasks can't point to the project name anymore).

If there's an intent behind this behavior (allowing empty dataset names), please let me know and I'd gladly change it to a warning instead.

Perhaps another solution is `dataset_name = None if dataset_name == ""`? or modify the project name under this condition so it's got some ephemeral name to it and prevents the behavior of an existing project getting wiped out.

Let me know if a minimal example to reproduce the behavior is desired, I can put one together.
Outline of it is:
> create a task which creates a dataset with an empty string as the name, under the same project name, get it into the UI in draft mode. Notice the project is visible. Presume this is already a project with hundreds of experiments in it and you just added a new task.
Run the task. When dataset completes, the project becomes hidden, appears to "vanish" from the UI (but is visible if hidden files are shown)

If the dataset project name differed from the "existing" project, then the original project is untouched, and the dataset-without-a-name is just under a hidden project.

If the dataset name is anything other than an empty string, everything works as anticipated, dataset lives under the right project, nothing is "hidden" that "shouldn't be".


## Related Issue \ discussion
https://clearml.slack.com/archives/CTK20V944/p1690230961759919

## Patch Description
raises error, prevents user from naming a dataset with an empty string.

## Testing Instructions
create a task that creates a dataset. notice the dataset's project is hidden upon completion. if the project names are the same, this makes it look like the task's entire project disappeared from the UI.

## Other Information
