### PR TITLE
Add timeout on program exit

### DIFF
--- a/clearml/backend_interface/metrics/reporter.py
+++ b/clearml/backend_interface/metrics/reporter.py
@@ -314,7 +314,7 @@ class Reporter(InterfaceBase, AbstractContextManager, SetupUploadMixin, AsyncMan
     def _handle_program_exit(self):
         try:
             self.flush()
-            self.wait_for_events()
+            self.wait_for_events(timeout=10)
             self.stop()
         except Exception as e:
             logging.getLogger("clearml.reporter").warning(


### PR DESCRIPTION
I have some issues currently where some scripts never finish as clearml is stuck waiting for events, I'm not sure why it happens but there should be a timeout anyway.

## Related Issue \ discussion
If this patch originated from a github issue or slack conversation, please paste a link to the original discussion<br/>

## Patch Description
Description of what does the patch do. If the patch solves a bug, explain what the bug is and how to reproduce it 
(If not already mentioned in the original conversation)<br/>

## Testing Instructions
Instructions of how to test the patch or reproduce the issue the patch is aiming to solve

## Other Information
