### PR TITLE
an option to download only added files for a given dataset version

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -910,7 +910,7 @@ class Dataset(object):
             Task.TaskStatusEnum.in_progress, Task.TaskStatusEnum.created, Task.TaskStatusEnum.failed)
 
     def get_local_copy(self, use_soft_links=None, part=None, num_parts=None, raise_on_error=True, max_workers=None,
-                       only_added=False):
+                       ignore_parent_datasets=False):
         # type: (bool, Optional[int], Optional[int], bool, Optional[int], bool) -> str
         """
         Return a base folder with a read-only (immutable) local copy of the entire dataset
@@ -931,7 +931,7 @@ class Dataset(object):
         :param raise_on_error: If True, raise exception if dataset merging failed on any file
         :param max_workers: Number of threads to be spawned when getting the dataset copy. Defaults
             to the number of logical cores.
-        :param only_added: If True, ignore all the parent datasets and download only files added to the latest version
+        :param ignore_parent_datasets: If True, ignore all the parent datasets and download only files added to the latest version
 
         :return: A base folder for the entire dataset
         """
@@ -944,7 +944,7 @@ class Dataset(object):
             raise ValueError("Cannot get a local copy of a dataset that was not finalized/closed")
         max_workers = max_workers or psutil.cpu_count()
 
-        if only_added:
+        if ignore_parent_datasets:
             # merge only added files, ignoring the parents
             if part is not None or num_parts is not None:
                 LoggerRoot.get_base_logger().info("Getting only added files, ignoring parents")


### PR DESCRIPTION

So far, when calling `get_local_copy` method on a `clearml.Dataset` object, you would download all the files from the dataset AND all its parents recursively, or create soft links for all files that have been downloaded previously. But there was no way to get only files added to this particular version of the dataset, ignoring all the parents. This little PR implements this exact feature.

## Testing Instructions

1. Register a `parent` dataset and add some files
2. Register a `child` dataset, inherited from the first one, and add some more files
3. Use `only_added` argument (`False` by default):
```
from clearml import Dataset
dataset = Dataset.get(dataset_name='child')
data_base_dir = dataset.get_local_copy(only_added=True)
```
`data_base_dir` will contain only files returned by `list_added_files`

## Other Information

Potential issue:

Soft links are still being created for files in the diff which have already been downloaded - this is ok

But it you first call `child.get_local_copy(only_added=True)` and then once again `child.get_local_copy()`, it will not create soft links for existing files and download the diff once again -- probably not ok... The same applies to "grandchildren" datasets. Still figuring out why. On the other hand, this could be ok if we assume `only_added=True` flag is supposed to be used only for debug purposes or to quickly inspect datasets.