### PR TITLE
Remove `subdir` path from GCP bucket url

### DIFF
--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -894,7 +894,7 @@ class _GoogleCloudStorageDriver(_Driver):
         obj.download_to_filename(str(p))
 
     def test_upload(self, test_path, config, **_):
-        bucket_url = str(furl(scheme=self.scheme, netloc=config.bucket, path=config.subdir))
+        bucket_url = str(furl(scheme=self.scheme, netloc=config.bucket))
         bucket = self.get_container(container_name=bucket_url, config=config).bucket
 
         test_obj = bucket


### PR DESCRIPTION
## Patch Description
When running a cloned task remotely and using GS as storage, calling `task.logger.set_default_upload_destination` usually fails with an error like:
```
GET https://storage.googleapis.com/storage/v1/b/clearml/project_a/.pipelines/Main/task_1.d7691550c955409db4622fd74496f51c/artifacts/result_TRAIN_config/result_TRAIN_config.pkl/iam/testPermissions?permissions=storage.objects.get&permissions=storage.objects.update&prettyPrint=false: Not Found
```
This is because the permissions are being tested on a single file instead of a GS bucket. Removing the `subdir` from the bucket url should fix it.

## Testing Instructions
- Run a pipeline with a single task that calls `task.logger.set_default_upload_destination`
- Clone the task and enqueue it again for execution
