### PR TITLE
address DeprecationWarnings from jsonschema

### DIFF
--- a/clearml/backend_api/session/request.py
+++ b/clearml/backend_api/session/request.py
@@ -2,12 +2,17 @@ import abc
 
 import six
 from jsonschema.exceptions import FormatError, SchemaError, ValidationError
-from referencing.exceptions import Unresolvable
+
+try:
+    # Since `referencing`` only supports Python >= 3.8, this try-except blocks maintain support
+    # for earlier python versions.
+    from referencing.exceptions import Unresolvable
+except ImportError:
+    from jsonschema.exceptions import RefResolutionError as Unresolvable
 
 from .apimodel import ApiModel
 from .datamodel import DataModel
 from .defs import ENV_API_DEFAULT_REQ_METHOD
-
 
 if ENV_API_DEFAULT_REQ_METHOD.exists() and ENV_API_DEFAULT_REQ_METHOD.get().upper() not in ("GET", "POST", "PUT"):
     raise ValueError(

--- a/clearml/backend_api/session/request.py
+++ b/clearml/backend_api/session/request.py
@@ -1,7 +1,8 @@
 import abc
 
-import jsonschema
 import six
+from jsonschema.exceptions import FormatError, SchemaError, ValidationError
+from referencing.exceptions import Unresolvable
 
 from .apimodel import ApiModel
 from .datamodel import DataModel
@@ -39,8 +40,7 @@ class BatchRequest(Request):
 
     _batched_request_cls = abc.abstractproperty()
 
-    _schema_errors = (jsonschema.SchemaError, jsonschema.ValidationError, jsonschema.FormatError,
-                      jsonschema.RefResolutionError)
+    _schema_errors = (SchemaError, ValidationError, FormatError, Unresolvable)
 
     def __init__(self, requests, validate_requests=False, allow_raw_requests=True, **kwargs):
         super(BatchRequest, self).__init__(**kwargs)
@@ -70,8 +70,7 @@ class BatchRequest(Request):
         for i, req in enumerate(self.requests):
             try:
                 req.validate()
-            except (jsonschema.SchemaError, jsonschema.ValidationError,
-                    jsonschema.FormatError, jsonschema.RefResolutionError) as e:
+            except (SchemaError, ValidationError, FormatError, Unresolvable) as e:
                 raise Exception('Validation error in batch item #%d: %s' % (i, str(e)))
 
     def get_json(self):

--- a/clearml/backend_api/session/request.py
+++ b/clearml/backend_api/session/request.py
@@ -14,6 +14,7 @@ from .apimodel import ApiModel
 from .datamodel import DataModel
 from .defs import ENV_API_DEFAULT_REQ_METHOD
 
+
 if ENV_API_DEFAULT_REQ_METHOD.exists() and ENV_API_DEFAULT_REQ_METHOD.get().upper() not in ("GET", "POST", "PUT"):
     raise ValueError(
         "CLEARML_API_DEFAULT_REQ_METHOD environment variable must be 'get' or 'post' (any case is allowed)."

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ python-dateutil>=2.6.1
 pyjwt>=2.4.0,<2.5.0 ; python_version > '3.5'
 pyjwt>=1.6.4,<2.0.0 ; python_version <= '3.5'
 PyYAML>=3.12
+referencing<0.40 ; python_version >= '3.8'
 requests>=2.20.0
 six>=1.13.0
 typing>=3.6.4 ; python_version < '3.5'


### PR DESCRIPTION
## Related Issue \ discussion
N/A<br/>

## Patch Description
Address the DeprecationWarning raised from `jsonschema`. My VSCode testing configuration treats DeprecationWarnings as Error, which means I cannot run any tests with VSCode testing when having clearml installed.

```
E   DeprecationWarning: Importing FormatError directly from the jsonschema package is deprecated and will become an ImportError. Import it from jsonschema.exceptions instead.
```

## Testing Instructions

```python
>>> import jsonschema
>>> jsonschema.FormatError
<stdin>:1: DeprecationWarning: Importing FormatError directly from the jsonschema package is deprecated and will become an ImportError. Import it from jsonschema.exceptions instead.
<class 'jsonschema.exceptions.FormatError'>
```

## Other Information
