### PR TITLE
Allow lightgbm model loading from a string instead of file

### DIFF
--- a/clearml/binding/frameworks/lightgbm_bind.py
+++ b/clearml/binding/frameworks/lightgbm_bind.py
@@ -71,7 +71,7 @@ class PatchLIGHTgbmModelIO(PatchBaseModelIO):
         return ret
 
     @staticmethod
-    def _load(original_fn, model_file, *args, **kwargs):
+    def _load(original_fn, model_file=None, *args, **kwargs):
         if not PatchLIGHTgbmModelIO._current_task:
             return original_fn(model_file, *args, **kwargs)
 


### PR DESCRIPTION
## Related Issue \ discussion
https://github.com/allegroai/clearml/issues/1135

## Patch Description
Allow loading of a LightGBM model from a string instead of from file.

## Testing Instructions
Try the code in the original issue with and without this change.

## Other Information
