### PR TITLE
Fix issue 1177

### DIFF
--- a/clearml/cli/data/__main__.py
+++ b/clearml/cli/data/__main__.py
@@ -9,6 +9,7 @@ from pathlib2 import Path
 
 import clearml.backend_api.session
 from clearml.datasets import Dataset
+from clearml.task import Task
 from clearml.version import __version__
 
 clearml.backend_api.session.Session.add_client("clearml-data", __version__)
@@ -437,6 +438,11 @@ def ds_get(args):
     print("Download dataset id {}".format(args.id))
     check_null_id(args)
     print_args(args)
+
+    task = Task.get_task(args.id)    
+    if 'dataset' not in task.get_system_tags():
+        print('Task {} is not a dataset task'.format(args.id))
+
     ds = Dataset.get(dataset_id=args.id)
     if args.overwrite:
         if args.copy:

--- a/clearml/version.py
+++ b/clearml/version.py
@@ -1,1 +1,1 @@
-__version__ = '1.13.3rc0'
+__version__ = '1.13.3dev1'


### PR DESCRIPTION
## Related Issue \ discussion
Relates to #1177 - Providing a task ID to clearml-data get results in unintuitive behaviour.

## Patch Description
Bug in original conversation. This patch checks for existance of the dataset tag before proceeding to get.

