### PR TITLE
Fix missing component callbacks on multiple step calls

### DIFF
--- a/clearml/automation/controller.py
+++ b/clearml/automation/controller.py
@@ -4075,6 +4075,13 @@ class PipelineDecorator(PipelineController):
                     ):
                         _node.name = "{}_{}".format(_node_name, counter)
                         counter += 1
+                    # Copy callbacks to the replicated node
+                    if cls._singleton._pre_step_callbacks.get(_node_name):
+                        cls._singleton._pre_step_callbacks[_node.name] = cls._singleton._pre_step_callbacks[_node_name]
+                    if cls._singleton._post_step_callbacks.get(_node_name):
+                        cls._singleton._post_step_callbacks[_node.name] = cls._singleton._post_step_callbacks[_node_name]
+                    if cls._singleton._status_change_callbacks.get(_node_name):
+                        cls._singleton._status_change_callbacks[_node.name] = cls._singleton._status_change_callbacks[_node_name]
                     _node_name = _node.name
                     if _node.name not in cls._singleton._nodes:
                         cls._singleton._nodes[_node.name] = _node


### PR DESCRIPTION
## Patch Description
When a pipeline step is called multiple times, if a `pre_execute_callback`, `pre_execute_callback` or `status_change_callback` is set, it is called only the first time.

## Testing Instructions
Minimal example:

```python
from clearml import PipelineDecorator

def pre_callaback(pipeline, node, parameters):
    print(node.name)

@PipelineDecorator.component(name='step', pre_execute_callback=pre_callaback)
def step(i: int):
    return i + 1

@PipelineDecorator.pipeline(name='test', project='test')
def pipeline():
    for i in range(5):
        step(i)

if __name__ == '__main__':
    PipelineDecorator.run_locally()
    pipeline()
```

This will print `step` only once, while I would expect to see it 5 times.

With this patch, the callbacks are copied to each node replica, and the output shows:
```
step
step_1
step_2
step_3
step_4
```