### PR TITLE
Fix UTF-8 script code encoding issue (#1207)

### DIFF
--- a/clearml/backend_interface/task/repo/scriptinfo.py
+++ b/clearml/backend_interface/task/repo/scriptinfo.py
@@ -912,7 +912,7 @@ class ScriptInfo(object):
 
         # noinspection PyBroadException
         try:
-            with open(script_path, 'r') as f:
+            with open(script_path, 'r', encoding='utf-8') as f:
                 script_code = f.read()
             return script_code
         except Exception:


### PR DESCRIPTION
## Related Issue \ discussion
https://github.com/allegroai/clearml/issues/1207

## Patch Description
Set utf-8 encoding for reading the script code

## Testing Instructions
Successfully tested on the script attached to the issue