### PR TITLE
Fix path substitution for file:// URIs

### DIFF
--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -2815,7 +2815,7 @@ class StorageHelper(object):
         :param str path: file path to check access to
         :return: Return the string representation of the file as path if have access to it, else None
         """
-
+        path = self._canonize_url(path)
         return self._driver.get_direct_access(path)
 
     @classmethod


### PR DESCRIPTION
## Related Issue \ discussion
Fix for #1233. See also #1217.

## Patch Description
Perform url canonization in `StorageHelper.get_driver_direct_access()`. It is performed in all relevant methods on `StorageHelper`: [here](https://github.com/allegroai/clearml/blob/e6e628517a865c5c1195ef5d661efc54437ac9e7/clearml/storage/helper.py#L2442) and [here](https://github.com/allegroai/clearml/blob/e6e628517a865c5c1195ef5d661efc54437ac9e7/clearml/storage/helper.py#L2487) and [here](https://github.com/allegroai/clearml/blob/e6e628517a865c5c1195ef5d661efc54437ac9e7/clearml/storage/helper.py#L2554) and [here](https://github.com/allegroai/clearml/blob/e6e628517a865c5c1195ef5d661efc54437ac9e7/clearml/storage/helper.py#L2606) and [here](https://github.com/allegroai/clearml/blob/e6e628517a865c5c1195ef5d661efc54437ac9e7/clearml/storage/helper.py#L2742) and [here](https://github.com/allegroai/clearml/blob/e6e628517a865c5c1195ef5d661efc54437ac9e7/clearml/storage/helper.py#L3002) and [here](https://github.com/allegroai/clearml/blob/e6e628517a865c5c1195ef5d661efc54437ac9e7/clearml/storage/helper.py#L3033).

## Testing Instructions
Described in #1233.

## Other Information
Test for dataset creation and loading. Loading works as expected. Creation works and will write the data to the path with substitution applied while the stored name will not have substitution applied (this is the expected behavior).

I could only test for `file://`. Could not check the effect on other uri types (e.g., AWS).
