### PR TITLE
Fix python-fire integration (issue #/1268)

### DIFF
--- a/clearml/binding/fire_bind.py
+++ b/clearml/binding/fire_bind.py
@@ -162,7 +162,7 @@ class PatchFire:
 
     @staticmethod
     def __CallAndUpdateTrace(  # noqa
-        original_fn, component, args_, component_trace, treatment, target, *args, **kwargs
+        original_fn, component, args_, component_trace, treatment, target=None, *args, **kwargs
     ):
         if running_remotely():
             return original_fn(component, args_, component_trace, treatment, target, *args, **kwargs)


### PR DESCRIPTION
## Related Issue \ discussion
Check #1268

## Patch Description
ClearML reassignes python-fire function [`_CallAndUpdateTrace`](https://github.com/google/python-fire/blob/6902939a317dca9d41446168d8e88f108e0c0f11/fire/core.py#L660) with the [`_patched_call`](https://github.com/allegroai/clearml/blob/54418060ae94179a35bfef00c83c292ebfa5f13d/clearml/binding/fire_bind.py#L62) wrapper call result. The first argument of `_patched_call` is `_CallAndUpdateTrace` itself and the second is [`__CallAndUpdateTrace`](https://github.com/allegroai/clearml/blob/54418060ae94179a35bfef00c83c292ebfa5f13d/clearml/binding/fire_bind.py#L164) from ClearML.
In the end, original function is [passed](https://github.com/allegroai/clearml/blob/54418060ae94179a35bfef00c83c292ebfa5f13d/clearml/binding/frameworks/__init__.py#L34) to the `__CallAndUpdateTrace` with all its arguments.

Original function [sets](https://github.com/google/python-fire/blob/6902939a317dca9d41446168d8e88f108e0c0f11/fire/core.py#L661) the default value for `target` argument as `None`. So it could be successfully called without passing this argument explicitly (done [there](https://github.com/google/python-fire/blob/6902939a317dca9d41446168d8e88f108e0c0f11/fire/core.py#L567)).
But when it comes to `__CallAndUpdateTrace` in ClearML - [there](https://github.com/allegroai/clearml/blob/54418060ae94179a35bfef00c83c292ebfa5f13d/clearml/binding/fire_bind.py#L165) is no default value for `target`. So it throws an error of missing positional argument as I mentioned in #1268
 
## Testing Instructions
Code example given in the related issue is enough for testing this behaviour.
