### PR TITLE
Fix typo in docs and default sdk config

### DIFF
--- a/clearml/config/default/sdk.conf
+++ b/clearml/config/default/sdk.conf
@@ -58,7 +58,7 @@
         iteration {
             # Max number of retries when getting frames if the server returned an error (http code 500)
             max_retries_on_server_error: 5
-            # Backoff factory for consecutive retry attempts.
+            # Backoff factor for consecutive retry attempts.
             # SDK will wait for {backoff factor} * (2 ^ ({number of total retries} - 1)) between retries.
             retry_backoff_factor_sec: 10
         }

--- a/docs/clearml.conf
+++ b/docs/clearml.conf
@@ -78,7 +78,7 @@ sdk {
         iteration {
             # Max number of retries when getting frames if the server returned an error (http code 500)
             max_retries_on_server_error: 5
-            # Backoff factory for consecutive retry attempts.
+            # Backoff factor for consecutive retry attempts.
             # SDK will wait for {backoff factor} * (2 ^ ({number of total retries} - 1)) between retries.
             retry_backoff_factor_sec: 10
         }

--- a/docs/trains.conf
+++ b/docs/trains.conf
@@ -64,7 +64,7 @@ sdk {
         iteration {
             # Max number of retries when getting frames if the server returned an error (http code 500)
             max_retries_on_server_error: 5
-            # Backoff factory for consecutive retry attempts.
+            # Backoff factor for consecutive retry attempts.
             # SDK will wait for {backoff factor} * (2 ^ ({number of total retries} - 1)) between retries.
             retry_backoff_factor_sec: 10
         }


### PR DESCRIPTION
## Related Issue / Discussion
Issue #1280
In the default configuration file for the SDK, the `retry_backoff_factor_sec` option has a comment that states it is the `Backoff factory...` instead of `Backoff factor...`.

## Patch Description
This patch replaces the word `factory` with `factor` in three files: [sdk.conf](https://github.com/allegroai/clearml/blame/b5a1299ac7860d1b64412199f6e7a5db84abd3bb/clearml/config/default/sdk.conf#L61), [clearml.conf](https://github.com/allegroai/clearml/blame/b5a1299ac7860d1b64412199f6e7a5db84abd3bb/docs/clearml.conf#L81), and [trains.conf](https://github.com/allegroai/clearml/blame/b5a1299ac7860d1b64412199f6e7a5db84abd3bb/docs/trains.conf#L67).

## Testing Instructions
No testing is required. The change is purely semantic.

## Other Information
I noticed this while reviewing the default configuration in my Python clearml sdk installation. I couldn't find any indication that this option has to do with any type of *factory*, and believe it is just a typo that has persisted since the first beta version commits.
