### PR TITLE
Fix `_patched_call` using along with Python Fire 

### DIFF
--- a/clearml/binding/fire_bind.py
+++ b/clearml/binding/fire_bind.py
@@ -6,7 +6,7 @@ except ImportError:
     fire = None
 
 import inspect
-from .frameworks import _patched_call  # noqa
+from .frameworks import _patched_call_no_recursion_guard  # noqa
 from ..config import get_remote_task_id, running_remotely
 from ..utilities.dicts import cast_str_to_bool
 
@@ -57,9 +57,9 @@ class PatchFire:
         if not cls.__patched:
             cls.__patched = True
             if running_remotely():
-                fire.core._Fire = _patched_call(fire.core._Fire, PatchFire.__Fire)
+                fire.core._Fire = _patched_call_no_recursion_guard(fire.core._Fire, PatchFire.__Fire)
             else:
-                fire.core._CallAndUpdateTrace = _patched_call(
+                fire.core._CallAndUpdateTrace = _patched_call_no_recursion_guard(
                     fire.core._CallAndUpdateTrace, PatchFire.__CallAndUpdateTrace
                 )
 


### PR DESCRIPTION
## Related Issue \ discussion
See #1300 

## Patch Description
Wraps Fire call with `_patched_call_no_recursion_guard` instead of `_patched_call`. This allows other functions wrapped with `_patched_call` to be used under the Fire scope as intended.

## Testing Instructions
Detailed code examples and discussion could be find in the related issue.
