### PR TITLE
fix for local file uploads without scheme

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -3350,6 +3350,8 @@ class Dataset(object):
         # noinspection PyBroadException
         try:
             if StorageManager.exists_file(source_url):
+                # handle local path provided without scheme
+                source_url = StorageHelper.sanitize_url(source_url)
                 remote_objects = [StorageManager.get_metadata(source_url, return_full_path=True)]
             elif not source_url.startswith(("http://", "https://")):
                 if source_url[-1] != "/":
@@ -3368,7 +3370,7 @@ class Dataset(object):
             link = remote_object.get("name")
             relative_path = link[len(source_url):]
             if not relative_path:
-                relative_path = source_url.split("/")[-1]
+                relative_path = os.path.basename(source_url)
             if not matches_any_wildcard(relative_path, wildcard, recursive=recursive):
                 continue
             try:

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -3067,6 +3067,14 @@ class StorageHelper(object):
         return self._driver.exists_file(
             container_name=self._container.name if self._container else "", object_name=object_name
         )
+    
+    @classmethod
+    def sanitize_url(cls, remote_url):
+        base_url = cls._resolve_base_url(remote_url)
+        if base_url != 'file://':
+            return remote_url
+        absoulte_path = os.path.abspath(remote_url)
+        return base_url + absoulte_path
 
 
 def normalize_local_path(local_path):


### PR DESCRIPTION
Fix issue on scenario where local file path is provided without scheme in add_external_file functionality.

## Related Issue \ discussion
Fix for [#1313 ](https://github.com/allegroai/clearml/issues/1313)

## Patch Description
If the file added has a local path, the absolute path is fetched and the 'file://' scheme is added.

## Testing Instructions
Described in [#1313]

## Other Information
Tested file addition using absolute path, relative path and remote path. File addition and upload is working fine.
I could only test for Windows system.
<img width="714" alt="image" src="https://github.com/user-attachments/assets/ef69bdaf-837a-4f6b-a062-6988f0227619">
