### PR TITLE
clearml-data search formatting error fix

### DIFF
--- a/clearml/cli/data/__main__.py
+++ b/clearml/cli/data/__main__.py
@@ -656,7 +656,7 @@ def ds_search(args):
             formatting.format(
                 d["project"],
                 d["name"],
-                d["version"],
+                d["version"] or "",
                 str(d["tags"] or [])[1:-1],
                 str(d["created"]).split(".")[0],
                 d["id"],


### PR DESCRIPTION
When formatting the output for clearml-data search cli, if the version is None, the code throws an error. Fixed it by assigning an empty "" when the dataset version is None.

## Related Issue \ discussion
[#1321 ]

## Patch Description
Assigning the dataset version to empty string if it is None when formatting the output.

## Testing Instructions
Tested in Windows environment. The datasets are getting listed as expected.
![Screenshot 2024-09-17 181157](https://github.com/user-attachments/assets/bad05476-de43-43c6-870c-33ae05136df0)

## Other Information
