### PR TITLE
Specify Task.TaskTypes as a type using typing.TypeAlias.

### DIFF
--- a/clearml/task.py
+++ b/clearml/task.py
@@ -9,6 +9,7 @@ import time
 from argparse import ArgumentParser
 from logging import getLogger
 from tempfile import mkstemp, mkdtemp
+from typing import TypeAlias
 from zipfile import ZipFile, ZIP_DEFLATED
 
 try:
@@ -161,7 +162,7 @@ class Task(_Task):
         Task. Creating a sub-task always creates a new Task with a new  Task ID.
     """
 
-    TaskTypes = _Task.TaskTypes
+    TaskTypes = _Task.TaskTypes  # type: TypeAlias
 
     NotSet = object()
 


### PR DESCRIPTION
Allows mypy to correctly identify it as a type.

## Related Issue \ discussion
If this patch originated from a github issue or slack conversation, please paste a link to the original discussion<br/>

## Patch Description
Description of what does the patch do. If the patch solves a bug, explain what the bug is and how to reproduce it 
(If not already mentioned in the original conversation)<br/>

Example:

Current Behaviour:

```
from clearml import Task

class Example:
    task_type: Task.TaskTypes = Task.TaskTypes.application
```

```
mypy example.py
example.py:4: error: Variable "clearml.task.Task.TaskTypes" is not valid as a type  [valid-type]
example.py:4: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
Found 1 error in 1 file (checked 1 source file)
```

with fix:
```
mypy example.py             
Success: no issues found in 1 source file
```

## Testing Instructions
Instructions of how to test the patch or reproduce the issue the patch is aiming to solve

See above snippets.
Using `mypy==1.61.1`, `clearml==2.0.2`

## Other Information
