### PR TITLE
FIX: Task.init fails for tags with tuple type

### DIFF
--- a/clearml/task.py
+++ b/clearml/task.py
@@ -1,3 +1,5 @@
+import itertools
+
 import numpy
 import copy
 import json
@@ -1963,7 +1965,11 @@ class Task(_Task):
         if isinstance(tags, six.string_types):
             tags = tags.split(" ")
 
-        self.data.tags = list(set((self.data.tags or []) + tags))
+        self.data.tags = list(
+            set(
+                itertools.chain(self.data.tags or [], tags)
+            )
+        )
         self._edit(tags=self.data.tags)
 
     def connect(


### PR DESCRIPTION
## Patch Description
`Task.init` method accepts tags with type hint `Optional[Sequence[str]]`. If we send tags with tuple type - for example `("test", "hello")` - function fails with exception., despite the fact that `tuple[str]` is a subset of `Sequence[str]`.
This PR fixes the reason of the error and allows user to use tuple as input tags.

## Testing Instructions
Just send `tuple[str]` as tags to the `Task.init`
<img width="351" height="138" alt="image" src="https://github.com/user-attachments/assets/76be45f4-2999-4f00-a6d0-4d2f4c8fc27a" />
<img width="1099" height="266" alt="image" src="https://github.com/user-attachments/assets/948e17f8-00ab-4003-aece-674840756c3b" />

After fix:
<img width="416" height="226" alt="image" src="https://github.com/user-attachments/assets/a8d4b249-12b3-42bd-b2b9-f69c016685d7" />
<img width="914" height="134" alt="image" src="https://github.com/user-attachments/assets/9b4db341-bdd2-469f-b6c5-430980b55747" />
