### PR TITLE
Make sure git diffs are always valid inputs for `git apply`

### DIFF
--- a/clearml/backend_interface/task/repo/detectors.py
+++ b/clearml/backend_interface/task/repo/detectors.py
@@ -251,7 +251,7 @@ class GitDetector(Detector):
             commit=["git", "rev-parse", "HEAD"],
             root=["git", "rev-parse", "--show-toplevel"],
             status=["git", "status", "-s"],
-            diff=["git", "diff", "--submodule=diff", "HEAD"],
+            diff=["git", "diff", "--submodule=diff", "--default-prefix", "HEAD"],
             modified=["git", "ls-files", "-m"],
             branch_fallback=["git", "rev-parse", "--abbrev-ref", "HEAD"],
             diff_fallback=["git", "diff", "HEAD"],


### PR DESCRIPTION
## Patch Description

`--default-prefix` is the default, but may be overridden by the user in his .gitconfig using:

```
[diff]
    	noprefix = true
```

which means the generated diffs won't have the "a/..." "b/..." prefixes. This breaks `git apply` and leads to errors with clearml remote executions:

```
Applying uncommitted changes
Executing: ('git', 'apply', '--unidiff-zero'): b'error: src/foo.py: No such file or directory\n'
Failed applying diff
NOTE: files were not found when applying diff, perhaps you forgot to push your changes?
clearml_agent: ERROR: Failed applying git diff:
diff --git src/foo.py src/foo.py
...
```

## Testing Instructions

Apply the .gitconfig change from above, then run a task with `execute_remotely` with uncommited changes.
