### PR TITLE
Update datetime/timezone usage to the non-deprecated pattern

### DIFF
--- a/clearml/backend_interface/task/repo/scriptinfo.py
+++ b/clearml/backend_interface/task/repo/scriptinfo.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from copy import copy
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import partial
 from tempfile import gettempdir, mkdtemp
 from types import TracebackType
@@ -545,7 +545,7 @@ class _JupyterObserver(object):
                                 name="notebook",
                                 artifact_object=Path(local_jupyter_filename),
                                 preview="See `notebook preview` artifact",
-                                metadata={"UPDATE": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")},
+                                metadata={"UPDATE": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")},
                                 wait_on_upload=True,
                             )
                             # noinspection PyBroadException
@@ -560,7 +560,7 @@ class _JupyterObserver(object):
                                     name="notebook preview",
                                     artifact_object=local_html,
                                     preview="Click `FILE PATH` link",
-                                    metadata={"UPDATE": datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")},
+                                    metadata={"UPDATE": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")},
                                     delete_after_upload=True,
                                     wait_on_upload=True,
                                 )

--- a/clearml/backend_interface/util.py
+++ b/clearml/backend_interface/util.py
@@ -1,27 +1,8 @@
 import getpass
 import re
 from _socket import gethostname
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Any
-
-try:
-    from datetime import timezone
-
-    utc_timezone = timezone.utc
-except ImportError:
-    from datetime import tzinfo, timedelta
-
-    class UTC(tzinfo):
-        def utcoffset(self, dt: datetime) -> timedelta:
-            return timedelta(0)
-
-        def tzname(self, dt: datetime) -> str:
-            return "UTC"
-
-        def dst(self, dt: datetime) -> timedelta:
-            return timedelta(0)
-
-    utc_timezone = UTC()
 
 from ..backend_api.services import projects, queues
 from ..debugging.log import get_logger, LoggerRoot
@@ -46,7 +27,7 @@ def make_message(s: str, **kwargs: Any) -> str:
     except Exception:
         host = "localhost"
 
-    args = dict(user=user, host=host, time=datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S"))
+    args = dict(user=user, host=host, time=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S"))
     args.update(kwargs)
     return s % args
 
@@ -190,7 +171,7 @@ def get_num_enqueued_tasks(session: Any, queue_id: str) -> Optional[int]:
 
 # Hack for supporting windows
 def get_epoch_beginning_of_time(timezone_info: Optional[Any] = None) -> datetime:
-    return datetime(1970, 1, 1).replace(tzinfo=timezone_info if timezone_info else utc_timezone)
+    return datetime(1970, 1, 1).replace(tzinfo=timezone_info if timezone_info else timezone.utc)
 
 
 def get_single_result(

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -18,7 +18,7 @@ from abc import ABCMeta, abstractmethod
 from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor, TimeoutError, CancelledError
 from copy import copy
-from datetime import datetime
+from datetime import datetime, timezone
 from multiprocessing.pool import ThreadPool, AsyncResult
 from multiprocessing import Lock
 from tempfile import mkstemp
@@ -897,7 +897,7 @@ class _Boto3Driver(_Driver):
             data = {
                 "user": getpass.getuser(),
                 "machine": gethostname(),
-                "time": datetime.utcnow().isoformat(),
+                "time": datetime.now(timezone.utc).isoformat(),
             }
 
             boto_session = boto3.Session(


### PR DESCRIPTION
The syntax `datetime.utcnow()` is deprecated since python 3.12: https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow

This PR replaces it with the newer `datetime.now(timezone.utc)` syntax and removes the compatibility utility `utc_timezone` from `clearml/backend_interface/util.py` since `timezone` has been available since python 3.2.