### PR TITLE
Fix PipelineController.is_successful() always returns False when a step is cached

### DIFF
--- a/clearml/automation/controller.py
+++ b/clearml/automation/controller.py
@@ -1457,6 +1457,8 @@ class PipelineController(object):
             return True
         self._update_nodes_status()
         for node in self._nodes.values():
+            if node.job and node.job.is_cached_task():
+                continue
             if node.status not in success_status:
                 return False
         return True


### PR DESCRIPTION
## Related Issue
#1501

## Testing Instructions
Described in issue

## Other Information
This is my first PR in clearml, feel free to let me know if something seems unclear or wrong.