### PR TITLE
Fix entrypoint bug when using local repo with PipelineController.add_function_step

### DIFF
--- a/clearml/backend_interface/task/populate.py
+++ b/clearml/backend_interface/task/populate.py
@@ -181,7 +181,7 @@ class CreateAndPopulate(object):
                 try:
                     if entry_point and Path(entry_point).is_file() and self.folder and Path(self.folder).is_dir():
                         # make sure we raise exception if this is outside the local repo folder
-                        entry_point = (Path(entry_point) / (Path(entry_point).relative_to(self.folder))).as_posix()
+                        entry_point = (Path(entry_point).parent / (Path(entry_point).relative_to(self.folder))).as_posix()
                 except ValueError:
                     entry_point = self.folder
                     stand_alone_script_outside_repo = True

--- a/clearml/backend_interface/task/populate.py
+++ b/clearml/backend_interface/task/populate.py
@@ -181,7 +181,8 @@ class CreateAndPopulate(object):
                 try:
                     if entry_point and Path(entry_point).is_file() and self.folder and Path(self.folder).is_dir():
                         # make sure we raise exception if this is outside the local repo folder
-                        entry_point = (Path(entry_point).parent / (Path(entry_point).relative_to(self.folder))).as_posix()
+                        Path(entry_point).relative_to(Path(self.folder))
+                        entry_point = Path(entry_point).as_posix()
                 except ValueError:
                     entry_point = self.folder
                     stand_alone_script_outside_repo = True


### PR DESCRIPTION
## Patch Description
Fixes a bug where the entrypoint becomes `script_path/script_filename` when setting repo to a local repo during Pipelines `add_function_step` call - i.e. if repo is `/home/user/repo`, the script path will be set to `/home/user/repo/tmp_xsasd.py`, but the current logic will update this already found absolute path to `/home/user/repo/tmp_xsasd.py/tmp_xsasd.py`, which leads to a TypeError in subsequent logic. The fix instead runs logic which raises a ValueError if entrypoint is outside the folder and keeps the original entrypoint since we already have the absolute path.

#### Broken example when using `repo`
```
import os

from clearml import PipelineController
# from clearml import Task

# Task.set_offline(True)

def example_func():
    return "Hello World!"

pipe = PipelineController(
  name="Pipeline Controller",
  project="Pipeline example",
  version="1.0.0",
)
pipe.add_function_step(
    name="example",
    function=example_func,
    repo=os.path.abspath(os.curdir),
)
pipe.start_locally(run_pipeline_steps_locally=True)
```

#### Traceback
```
 (main) charlesfrankum@charless-MacBook-Pro clearml-tools % python test.py
ClearML Task: created new task id=offline-24b5fa7c062d436c8c121a59906e0cd1
ClearML running in offline mode, session stored in /Users/charlesfrankum/.clearml/cache/offline/offline-24b5fa7c062d436c8c121a59906e0cd1
Traceback (most recent call last):
  File "/Users/charlesfrankum/Git/clearml-tools/test.py", line 17, in <module>
    pipe.add_function_step(
  File "/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/clearml/automation/controller.py", line 1031, in add_function_step
    return self._add_function_step(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/clearml/automation/controller.py", line 2719, in _add_function_step
    task_definition = self._create_task_from_function(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/clearml/automation/controller.py", line 1938, in _create_task_from_function
    task_definition = CreateFromFunction.create_task_from_function(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/clearml/backend_interface/task/populate.py", line 1010, in create_task_from_function
    task = populate.create_task(dry_run=dry_run)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/clearml/backend_interface/task/populate.py", line 197, in create_task
    Path(self.cwd).is_absolute()
    ^^^^^^^^^^^^^^
  File "/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/pathlib2/__init__.py", line 1347, in __new__
    self = cls._from_parts(args, init=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/pathlib2/__init__.py", line 978, in _from_parts
    drv, root, parts = self._parse_args(args)
                       ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/pathlib2/__init__.py", line 954, in _parse_args
    a = os.fspath(a)
        ^^^^^^^^^^^^
TypeError: expected str, bytes or os.PathLike object, not NoneType
Failed auto-detecting task repository: no info for [PosixPath('/Users/charlesfrankum/Git/clearml-tools'), PosixPath('/Users/charlesfrankum/venvs/main/lib/python3.12/site-packages/clearml/automation')] (_PyErr_SetObject: exception SystemExit() is not a BaseException subclass)
ClearML Task: Offline session stored in /Users/charlesfrankum/.clearml/cache/offline/offline-24b5fa7c062d436c8c121a59906e0cd1.zip
```

## Testing Instructions
In a different repo copy the example and run it from the root and it should throw this traceback. Apply the fix and then run again and it should use the correct entrypoint script and the run should complete. 
