### PR TITLE
Fix deprecation from pyparsing

### DIFF
--- a/clearml/utilities/pyhocon/config_parser.py
+++ b/clearml/utilities/pyhocon/config_parser.py
@@ -477,7 +477,7 @@ class ConfigParser(object):
             # the file can be { ... } where {} can be omitted or []
             config_expr = ZeroOrMore(comment_eol | eol) + (list_expr | root_dict_expr |
                                                            inside_root_dict_expr) + ZeroOrMore(comment_eol | eol_comma)
-            config = config_expr.parseString(content, parseAll=True)[0]
+            config = config_expr.parse_string(content, parseAll=True)[0]
 
             if resolve:
                 allow_unresolved = resolve and unresolved_value is not DEFAULT_SUBSTITUTION and \

--- a/clearml/utilities/pyhocon/config_parser.py
+++ b/clearml/utilities/pyhocon/config_parser.py
@@ -6,8 +6,27 @@ import contextlib
 import codecs
 from datetime import timedelta
 
-from pyparsing import Forward, Keyword, QuotedString, Word, Literal, Suppress, Regex, Optional, SkipTo, ZeroOrMore, \
-    Group, lineno, col, TokenConverter, replaceWith, alphanums, alphas8bit, ParseSyntaxException, StringEnd
+from pyparsing import (
+    Forward,
+    Keyword,
+    QuotedString,
+    Word,
+    Literal,
+    Suppress,
+    Regex,
+    Optional,
+    SkipTo,
+    ZeroOrMore,
+    Group,
+    lineno,
+    col,
+    TokenConverter,
+    replace_with,
+    alphanums,
+    alphas8bit,
+    ParseSyntaxException,
+    StringEnd,
+)
 from pyparsing import ParserElement
 from .config_tree import ConfigTree, ConfigSubstitution, ConfigList, ConfigValues, ConfigUnquotedString, \
     ConfigInclude, NoneValue, ConfigQuotedString
@@ -365,9 +384,15 @@ class ConfigParser(object):
 
         with set_default_white_spaces():
             assign_expr = Forward()
-            true_expr = Keyword("true", caseless=True).setParseAction(replaceWith(True))
-            false_expr = Keyword("false", caseless=True).setParseAction(replaceWith(False))
-            null_expr = Keyword("null", caseless=True).setParseAction(replaceWith(NoneValue()))
+            true_expr = Keyword("true", caseless=True).setParseAction(
+                replace_with(True)
+            )
+            false_expr = Keyword("false", caseless=True).setParseAction(
+                replace_with(False)
+            )
+            null_expr = Keyword("null", caseless=True).setParseAction(
+                replace_with(NoneValue())
+            )
             # key = QuotedString('"', escChar='\\', unquoteResults=False) | Word(alphanums + alphas8bit + '._- /')
             regexp_numbers = r'[+-]?(\d*\.\d+|\d+(\.\d+)?)([eE][+\-]?\d+)?(?=$|[ \t]*([\$\}\],#\n\r]|//))'
             key = QuotedString('"', escChar='\\', unquoteResults=False) | \

--- a/clearml/utilities/pyhocon/config_parser.py
+++ b/clearml/utilities/pyhocon/config_parser.py
@@ -359,9 +359,9 @@ class ConfigParser(object):
         @contextlib.contextmanager
         def set_default_white_spaces():
             default = ParserElement.DEFAULT_WHITE_CHARS
-            ParserElement.setDefaultWhitespaceChars(' \t')
+            ParserElement.set_default_whitespace_chars(" \t")
             yield
-            ParserElement.setDefaultWhitespaceChars(default)
+            ParserElement.set_default_whitespace_chars(default)
 
         with set_default_white_spaces():
             assign_expr = Forward()

--- a/clearml/utilities/pyhocon/config_parser.py
+++ b/clearml/utilities/pyhocon/config_parser.py
@@ -393,10 +393,10 @@ class ConfigParser(object):
             null_expr = Keyword("null", caseless=True).set_parse_action(
                 replace_with(NoneValue())
             )
-            # key = QuotedString('"', escChar='\\', unquoteResults=False) | Word(alphanums + alphas8bit + '._- /')
+            # key = QuotedString('"', esc_char='\\', unquote_results=False) | Word(alphanums + alphas8bit + '._- /')
             regexp_numbers = r'[+-]?(\d*\.\d+|\d+(\.\d+)?)([eE][+\-]?\d+)?(?=$|[ \t]*([\$\}\],#\n\r]|//))'
             key = (
-                QuotedString('"', escChar="\\", unquoteResults=False)
+                QuotedString('"', esc_char="\\", unquote_results=False)
                 | Regex(regexp_numbers, re.DOTALL).set_parse_action(safe_convert_number)
                 | Word(alphanums + alphas8bit + "._- /")
             )

--- a/clearml/utilities/pyhocon/config_parser.py
+++ b/clearml/utilities/pyhocon/config_parser.py
@@ -477,7 +477,7 @@ class ConfigParser(object):
             # the file can be { ... } where {} can be omitted or []
             config_expr = ZeroOrMore(comment_eol | eol) + (list_expr | root_dict_expr |
                                                            inside_root_dict_expr) + ZeroOrMore(comment_eol | eol_comma)
-            config = config_expr.parse_string(content, parseAll=True)[0]
+            config = config_expr.parse_string(content, parse_all=True)[0]
 
             if resolve:
                 allow_unresolved = resolve and unresolved_value is not DEFAULT_SUBSTITUTION and \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pathlib2>=2.3.0
 Pillow>=7.0.0 ; python_version < '3.8'
 Pillow>=10.3.0 ; python_version >= '3.8'
 psutil>=3.4.2
-pyparsing>=3.1.4
+pyparsing>=3.0.0
 python-dateutil>=2.6.1
 pyjwt>=2.4.0,<2.11.0
 PyYAML>=3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pathlib2>=2.3.0
 Pillow>=7.0.0 ; python_version < '3.8'
 Pillow>=10.3.0 ; python_version >= '3.8'
 psutil>=3.4.2
-pyparsing>=2.0.3
+pyparsing>=3.1.4
 python-dateutil>=2.6.1
 pyjwt>=2.4.0,<2.11.0
 PyYAML>=3.12


### PR DESCRIPTION
```
 .venv/lib/python3.13/site-packages/clearml/utilities/pyhocon/config_parser.py:362: in set_default_white_spaces
    ParserElement.setDefaultWhitespaceChars(' \t')
.venv/lib/python3.13/site-packages/pyparsing/util.py:445: in _inner
    warnings.warn(
E   DeprecationWarning: 'setDefaultWhitespaceChars' deprecated - use 'set_default_whitespace_chars'
```

And:

```
.venv/lib/python3.12/site-packages/clearml/utilities/pyhocon/config_parser.py:368: in parse
    true_expr = Keyword("true", caseless=True).setParseAction(replaceWith(True))
                                                              ^^^^^^^^^^^^^^^^^
.venv/lib/python3.12/site-packages/pyparsing/util.py:445: in _inner
    warnings.warn(
E   DeprecationWarning: 'replaceWith' deprecated - use 'replace_with'
``` 

Simple fix in this PR.