### PR TITLE
Add support for boto3 S3 specific configuration

### DIFF
--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -575,6 +575,7 @@ class _Boto3Driver(_Driver):
     _connect_timeout = deferred_config("aws.boto3.connect_timeout", 60)
     _read_timeout = deferred_config("aws.boto3.read_timeout", 60)
     _signature_version = deferred_config("aws.boto3.signature_version", None)
+    _s3 = deferred_config("aws.boto3.s3", {})
 
     _stream_download_pool_connections = deferred_config("aws.boto3.stream_connections", 128)
     _stream_download_pool = None
@@ -654,6 +655,7 @@ class _Boto3Driver(_Driver):
                 connect_timeout=int(_Boto3Driver._connect_timeout),
                 read_timeout=int(_Boto3Driver._read_timeout),
                 signature_version=_Boto3Driver._signature_version,
+                s3=_Boto3Driver._s3,
             ),
         }
         if not cfg.use_credentials_chain:

--- a/docs/clearml.conf
+++ b/docs/clearml.conf
@@ -164,6 +164,10 @@ sdk {
             max_multipart_concurrency: 16
             multipart_threshold: 8388608 # 8MB
             multipart_chunksize: 8388608 # 8MB
+            # Additional S3 specific configurations passed to boto3 client
+            # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html
+            # Example: addressing_style: "auto" # possible values: path, virtual, auto
+            s3: {}
         }
     }
     google.storage {


### PR DESCRIPTION
**Summary**
This PR adds support for passing S3-specific configuration options to the underlying boto3 client via the ClearML configuration file.

**Motivation**
Previously, the boto3 driver only supported a subset of configuration options (like timeouts and signature version). Some S3-compatible storage providers or specific network environments require setting additional S3 parameters in botocore.config.Config, most notably addressing_style (e.g., to force "path" style access).

**Changes**
[helper.py]: Updated _Boto3Driver to read aws.boto3.s3 from the configuration and pass it to the Config object initializer.
[clearml.conf]: Added the s3 section to the default configuration template with comments explaining its usage.

**How to test / Usage example**
Users can now add an s3 block under aws.boto3 in their configuration file:
```
aws {
    boto3 {
        # ... other settings
        s3 {
            addressing_style: "path"   # possible values: path, virtual, auto
            # Any other valid keys for botocore.config.Config s3 dictionary
        }
    }
}
