### PR TITLE
fix: correct typos in codebase

### DIFF
--- a/clearml/backend_api/services/v2_23/datasets.py
+++ b/clearml/backend_api/services/v2_23/datasets.py
@@ -4805,7 +4805,7 @@ class GetLabelKeywordsForRunningTaskResponse(Response):
     Response of datasets.get_label_keywords_for_running_task endpoint.
 
     :param labels: List of objects with properties: name - string - label name
-        count - integer - number of occurences
+        count - integer - number of occurrences
     :type labels: Sequence[dict]
     """
 
@@ -4819,7 +4819,7 @@ class GetLabelKeywordsForRunningTaskResponse(Response):
             "labels": {
                 "description": (
                     "List of objects with properties:\n                    name - string - label name\n                "
-                    "    count - integer - number of occurences"
+                    "    count - integer - number of occurrences"
                 ),
                 "items": {
                     "properties": {

--- a/clearml/backend_api/session/session.py
+++ b/clearml/backend_api/session/session.py
@@ -609,7 +609,7 @@ class Session(TokenManager):
                     # skip the payload that could not be sent
                     size = req_data[cur:].find("\n") + 1
                     if size == 0:
-                        # error occured on the last package
+                        # error occurred on the last package
                         break
             if slice:
                 res = self.send_request(

--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -708,7 +708,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
             return res.response.task
 
     def _reload_field(self, field: str) -> Any:
-        """Reload the task specific field, dot seperated for nesting"""
+        """Reload the task specific field, dot separated for nesting"""
         with self._edit_lock:
             if self._offline_mode:
                 task_object = self._reload()

--- a/clearml/utilities/gpu/pyrsmi.py
+++ b/clearml/utilities/gpu/pyrsmi.py
@@ -135,14 +135,14 @@ rsmi_status_verbose_err_out = {
     rsmi_status_t.RSMI_STATUS_OUT_OF_RESOURCES: 'Unable to acquire memory or other resource',
     rsmi_status_t.RSMI_STATUS_INTERNAL_EXCEPTION: 'An internal exception was caught',
     rsmi_status_t.RSMI_STATUS_INPUT_OUT_OF_BOUNDS: 'Provided input is out of allowable or safe range',
-    rsmi_status_t.RSMI_INITIALIZATION_ERROR: 'Error occured during rsmi initialization',
+    rsmi_status_t.RSMI_INITIALIZATION_ERROR: 'Error occurred during rsmi initialization',
     rsmi_status_t.RSMI_STATUS_NOT_YET_IMPLEMENTED: 'Requested function is not implemented on this setup',
     rsmi_status_t.RSMI_STATUS_NOT_FOUND: 'Item searched for but not found',
     rsmi_status_t.RSMI_STATUS_INSUFFICIENT_SIZE: 'Insufficient resources available',
-    rsmi_status_t.RSMI_STATUS_INTERRUPT: 'Interrupt occured during execution',
+    rsmi_status_t.RSMI_STATUS_INTERRUPT: 'Interrupt occurred during execution',
     rsmi_status_t.RSMI_STATUS_UNEXPECTED_SIZE: 'Unexpected amount of data read',
     rsmi_status_t.RSMI_STATUS_NO_DATA: 'No data found for the given input',
-    rsmi_status_t.RSMI_STATUS_UNKNOWN_ERROR: 'Unknown error occured'
+    rsmi_status_t.RSMI_STATUS_UNKNOWN_ERROR: 'Unknown error occurred'
 }
 
 


### PR DESCRIPTION
Fixes typos in 4 files:
- `occured` → `occurred` (pyrsmi.py, session.py)
- `occurences` → `occurrences` (datasets.py)
- `seperated` → `separated` (task.py)