### PR TITLE
Fix syntax error on python 3.14

### DIFF
--- a/clearml/binding/joblib_bind.py
+++ b/clearml/binding/joblib_bind.py
@@ -215,8 +215,7 @@ class PatchedJoblib(object):
             LoggerRoot.get_base_logger().debug(
                 "Can't get model framework {}, model framework will be: {} ".format(object_orig_module, framework)
             )
-        finally:
-            return framework
+        return framework
 
     @staticmethod
     def _cached_call_recursion_guard(original_fn: Callable, *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
A `return` in a `finally` block has been deprecated since Python 3.12 and now raises a `SyntaxError` in python 3.14.