### PR TITLE
Replace `six.text_type` usage by `str`

### DIFF
--- a/clearml/automation/optimization.py
+++ b/clearml/automation/optimization.py
@@ -1992,7 +1992,7 @@ class HyperParameterOptimizer(object):
                 for k, v in optimizer_kwargs.items()
                 if not isinstance(
                     v,
-                    six.string_types + six.integer_types + (six.text_type, float, list, tuple, dict, type(None)),
+                    six.string_types + six.integer_types + (str, float, list, tuple, dict, type(None)),
                 )
             }
             kwargs["optimizer_kwargs"] = {

--- a/clearml/backend_api/session/jsonmodels/utilities.py
+++ b/clearml/backend_api/session/jsonmodels/utilities.py
@@ -18,9 +18,9 @@ PYTHON_TO_ECMA_FLAGS = dict((value, key) for key, value in ECMA_TO_PYTHON_FLAGS.
 PythonRegex = namedtuple("PythonRegex", ["regex", "flags"])
 
 
-def _normalize_string_type(value: Any) -> Union[six.text_type, Any]:
+def _normalize_string_type(value: Any) -> Union[str, Any]:
     if isinstance(value, six.string_types):
-        return six.text_type(value)
+        return str(value)
     else:
         return value
 

--- a/clearml/backend_config/converters.py
+++ b/clearml/backend_config/converters.py
@@ -1,8 +1,6 @@
 import base64
 from typing import Union, Optional, Any, TypeVar, Callable, Tuple
 
-import six
-
 try:
     from typing import Text
 except ImportError:
@@ -44,7 +42,7 @@ def safe_text_to_bool(value: Text) -> bool:
 
 
 def any_to_bool(value: Optional[Union[int, float, Text]]) -> bool:
-    if isinstance(value, six.text_type):
+    if isinstance(value, str):
         return text_to_bool(value)
     return bool(value)
 

--- a/clearml/backend_config/entry.py
+++ b/clearml/backend_config/entry.py
@@ -26,7 +26,7 @@ class Entry(object):
     def default_conversions(cls) -> Dict[Any, Converter]:
         return {
             bool: any_to_bool,
-            six.text_type: lambda s: six.text_type(s).strip(),
+            str: lambda s: str(s).strip(),
         }
 
     def __init__(self, key: Text, *more_keys: Text, **kwargs: Any) -> None:
@@ -42,7 +42,7 @@ class Entry(object):
         :param help: Help text describing this entry
         """
         self.keys = (key,) + more_keys
-        self.type = kwargs.pop("type", six.text_type)
+        self.type = kwargs.pop("type", str)
         self.converter = kwargs.pop("converter", None)
         self.default = kwargs.pop("default", None)
         self.help = kwargs.pop("help", None)

--- a/clearml/backend_interface/model.py
+++ b/clearml/backend_interface/model.py
@@ -601,7 +601,7 @@ class Model(IdObjectBase, AsyncManagerMixin, _StorageUriMixin):
         # if p.is_file():
         #     return str(p)
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(six.text_type(design))
+        p.write_text(str(design))
         return str(p)
 
     def get_model_package(self) -> ModelPackage:

--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -207,7 +207,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
             set(
                 six.string_types
                 + six.integer_types
-                + (six.text_type, float, list, tuple, dict, type(None), Enum)  # noqa
+                + (str, float, list, tuple, dict, type(None), Enum)  # noqa
             )
         )
         self._app_server = None

--- a/clearml/model.py
+++ b/clearml/model.py
@@ -2542,7 +2542,7 @@ class OutputModel(BaseModel):
             raise ValueError("Model update weights package should get either directory path to pack or a list of files")
 
         if not weights_filenames:
-            weights_filenames = list(map(six.text_type, Path(weights_path).rglob("*")))
+            weights_filenames = list(map(str, Path(weights_path).rglob("*")))
         elif weights_filenames and len(weights_filenames) > 1:
             weights_path = get_common_path(weights_filenames)
 

--- a/clearml/task.py
+++ b/clearml/task.py
@@ -5505,7 +5505,7 @@ class Task(_Task):
         # compare after casting to string to avoid enum instance issues
         # remember we might have replaced the api version by now, so enums are different
         return all(
-            six.text_type(server_data) == six.text_type(task_data.get(task_data_key))
+            str(server_data) == str(task_data.get(task_data_key))
             for server_data, task_data_key in compares
         )
 

--- a/clearml/utilities/config.py
+++ b/clearml/utilities/config.py
@@ -116,7 +116,7 @@ def verify_basic_value(value: Any) -> bool:
     # return True if value of of basic type (json serializable)
     if not isinstance(
         value,
-        six.string_types + six.integer_types + (six.text_type, float, list, tuple, dict, type(None)),
+        six.string_types + six.integer_types + (str, float, list, tuple, dict, type(None)),
     ):
         return False
     try:

--- a/clearml/utilities/lowlevel/astor_unparse.py
+++ b/clearml/utilities/lowlevel/astor_unparse.py
@@ -46,7 +46,7 @@ class Unparser:
 
     def write(self, text: Any) -> None:
         """Append a piece of text to the current line."""
-        self.f.write(six.text_type(text))
+        self.f.write(str(text))
 
     def enter(self) -> None:
         """Print ':', and increase the indentation."""


### PR DESCRIPTION
## Related issue
#1529  

## Description
We have that `six.text_type == str` returns `True` in Python 3, so the former was replaced by the latter (and unused import of `six` was removed when necessary). Everything went smoothly. No linting errors occurred.