### PR TITLE
Remove explicit subclassing by `object`

### DIFF
--- a/clearml/automation/auto_scaler.py
+++ b/clearml/automation/auto_scaler.py
@@ -76,7 +76,7 @@ class ScalerConfig:
         )
 
 
-class AutoScaler(object):
+class AutoScaler:
     def __init__(
         self,
         config: "ScalerConfig",

--- a/clearml/automation/controller.py
+++ b/clearml/automation/controller.py
@@ -40,7 +40,7 @@ from ..utilities.proxy_object import (
 from ..utilities.version import Version
 
 
-class PipelineController(object):
+class PipelineController:
     """
     Pipeline controller.
     Pipeline is a DAG of base tasks, each task will be cloned (arguments changed as required), executed, and monitored.
@@ -90,7 +90,7 @@ class PipelineController(object):
     ]
 
     @attrs
-    class Node(object):
+    class Node:
         # pipeline step name
         name = attrib(type=str)
         # base Task ID to be cloned and launched

--- a/clearml/automation/job.py
+++ b/clearml/automation/job.py
@@ -22,7 +22,7 @@ from ..task import Task
 logger = getLogger("clearml.automation.job")
 
 
-class BaseJob(object):
+class BaseJob:
     _job_hash_description = "job_hash={}"
     _job_hash_property = "pipeline_job_hash"
     _hashing_callback = None
@@ -825,7 +825,7 @@ class TrainsJob(ClearmlJob):
 
 
 # noinspection PyMethodMayBeStatic, PyUnusedLocal
-class _JobStub(object):
+class _JobStub:
     """
     This is a Job Stub, use only for debugging
     """

--- a/clearml/automation/monitor.py
+++ b/clearml/automation/monitor.py
@@ -7,7 +7,7 @@ from ..backend_interface.util import exact_match_regex
 from ..task import Task
 
 
-class Monitor(object):
+class Monitor:
     """
     Base class for monitoring Tasks on the system.
     Inherit to implement specific logic

--- a/clearml/automation/optimization.py
+++ b/clearml/automation/optimization.py
@@ -293,8 +293,8 @@ class Objective(_ObjectiveInterface):
         )
 
 
-class Budget(object):
-    class Field(object):
+class Budget:
+    class Field:
         def __init__(self, limit: Optional[float] = None) -> ():
             self.limit = limit
             self.current = {}
@@ -340,7 +340,7 @@ class Budget(object):
         return current_budget
 
 
-class SearchStrategy(object):
+class SearchStrategy:
     """
     The base search strategy class. Inherit this class to implement your custom strategy.
     """
@@ -1356,7 +1356,7 @@ class RandomSearch(SearchStrategy):
         return self.helper_create_job(base_task_id=self._base_task_id, parameter_override=parameters)
 
 
-class HyperParameterOptimizer(object):
+class HyperParameterOptimizer:
     """
     Hyperparameter search controller. Clones the base experiment, changes arguments and tries to maximize/minimize
     the defined objective.

--- a/clearml/automation/optuna/optuna.py
+++ b/clearml/automation/optuna/optuna.py
@@ -20,7 +20,7 @@ except ImportError:
     raise ImportError("OptimizerOptuna requires 'optuna' package, it was not found\n install with: pip install optuna")
 
 
-class OptunaObjective(object):
+class OptunaObjective:
     def __init__(
         self,
         base_task_id: str,

--- a/clearml/automation/parameters.py
+++ b/clearml/automation/parameters.py
@@ -4,7 +4,7 @@ from random import Random as BaseRandom
 from typing import Mapping, Sequence, Optional, Union, Any
 
 
-class RandomSeed(object):
+class RandomSeed:
     """
     The base class controlling random sampling for every optimization strategy.
     """

--- a/clearml/automation/scheduler.py
+++ b/clearml/automation/scheduler.py
@@ -19,7 +19,7 @@ from ..task import Task
 
 
 @attrs
-class BaseScheduleJob(object):
+class BaseScheduleJob:
     name = attrib(type=str, default=None)
     base_task_id = attrib(type=str, default=None)
     base_function = attrib(type=Callable, default=None)
@@ -298,7 +298,7 @@ class ScheduleJob(BaseScheduleJob):
 
 
 @attrs
-class ExecutedJob(object):
+class ExecutedJob:
     name = attrib(type=str, default=None)
     started = attrib(type=datetime, converter=datetime_from_isoformat, default=None)
     finished = attrib(type=datetime, converter=datetime_from_isoformat, default=None)
@@ -309,7 +309,7 @@ class ExecutedJob(object):
         return {k: v for k, v in self.__dict__.items() if full or not str(k).startswith("_")}
 
 
-class BaseScheduler(object):
+class BaseScheduler:
     def __init__(
         self,
         sync_frequency_minutes: float = 15,

--- a/clearml/backend_api/api_proxy.py
+++ b/clearml/backend_api/api_proxy.py
@@ -7,7 +7,7 @@ from .session import Session
 from ..utilities.check_updates import Version
 
 
-class ApiServiceProxy(object):
+class ApiServiceProxy:
     _main_services_module = "clearml.backend_api.services"
     _available_versions = None
 

--- a/clearml/backend_api/schema/action.py
+++ b/clearml/backend_api/schema/action.py
@@ -15,7 +15,7 @@ def sequence_of(types: type) -> attr.validators._AndValidator:
 
 
 @attr.s
-class Action(object):
+class Action:
     name = attr.ib()
     version = attr.ib()
     service = attr.ib()

--- a/clearml/backend_api/schema/service.py
+++ b/clearml/backend_api/schema/service.py
@@ -9,7 +9,7 @@ from ...utilities.pyhocon import ConfigTree
 from .action import Action
 
 
-class Service(object):
+class Service:
     """Service schema handler"""
 
     __jsonschema_ref_ex = re.compile("^#/definitions/(.*)$")

--- a/clearml/backend_api/session/callresult.py
+++ b/clearml/backend_api/session/callresult.py
@@ -11,7 +11,7 @@ from .response import ResponseMeta, Response
 from .errors import ResultNotReadyError, TimeoutExpiredError
 
 
-class CallResult(object):
+class CallResult:
     @property
     def meta(self) -> ResponseMeta:
         return self.__meta

--- a/clearml/backend_api/session/client/client.py
+++ b/clearml/backend_api/session/client/client.py
@@ -141,7 +141,7 @@ class StrictSession(Session):
         return result
 
 
-class Response(object):
+class Response:
     """
     Proxy object for API result data.
     Exposes "meta" of the original result.
@@ -276,7 +276,7 @@ class TableResponse(Response):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Entity(object):
+class Entity:
     """
     Represent a server object.
     Enables calls like:
@@ -435,7 +435,7 @@ def make_action(service: "Service", request_cls: Type["APIRequest"]) -> Callable
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Service(object):
+class Service:
     """
     Superclass for action-grouping classes.
     """
@@ -511,7 +511,7 @@ class Version(Entity):
         return dict(super(Version, self)._get_default_kwargs(), **{"dataset": self.data.dataset})
 
 
-class APIClient(object):
+class APIClient:
     auth: Any = None
     queues: Any = None
     tasks: Any = None

--- a/clearml/backend_api/session/datamodel.py
+++ b/clearml/backend_api/session/datamodel.py
@@ -48,7 +48,7 @@ except ImportError:
     pass
 
 
-class DataModel(object):
+class DataModel:
     """Data Model"""
 
     _schema = None
@@ -154,7 +154,7 @@ class UnusedKwargsWarning(UserWarning):
     pass
 
 
-class NonStrictDataModelMixin(object):
+class NonStrictDataModelMixin:
     """
     NonStrictDataModelMixin
 

--- a/clearml/backend_api/session/jsonmodels/builders.py
+++ b/clearml/backend_api/session/jsonmodels/builders.py
@@ -11,7 +11,7 @@ from . import errors
 from .fields import NotSet
 
 
-class Builder(object):
+class Builder:
     def __init__(
         self,
         parent: "Builder" = None,

--- a/clearml/backend_api/session/jsonmodels/fields.py
+++ b/clearml/backend_api/session/jsonmodels/fields.py
@@ -14,7 +14,7 @@ from .collections import ModelCollection
 NotSet = object()
 
 
-class BaseField(object):
+class BaseField:
     """Base class for all fields."""
 
     types = None
@@ -346,7 +346,7 @@ class EmbeddedField(BaseField):
         return value.to_struct()
 
 
-class _LazyType(object):
+class _LazyType:
     def __init__(self, path: str) -> None:
         self.path = path
 

--- a/clearml/backend_api/session/jsonmodels/models.py
+++ b/clearml/backend_api/session/jsonmodels/models.py
@@ -142,5 +142,5 @@ class Base(six.with_metaclass(JsonmodelMeta, object)):
         return not (self == other)
 
 
-class _CacheKey(object):
+class _CacheKey:
     """Object to identify model in memory."""

--- a/clearml/backend_api/session/jsonmodels/validators.py
+++ b/clearml/backend_api/session/jsonmodels/validators.py
@@ -8,7 +8,7 @@ from .errors import ValidationError
 from . import utilities
 
 
-class Min(object):
+class Min:
     """Validator for minimum value."""
 
     def __init__(self, minimum_value: Any, exclusive: bool = False) -> None:
@@ -41,7 +41,7 @@ class Min(object):
             field_schema["exclusiveMinimum"] = True
 
 
-class Max(object):
+class Max:
     """Validator for maximum value."""
 
     def __init__(self, maximum_value: Any, exclusive: bool = False) -> None:
@@ -74,7 +74,7 @@ class Max(object):
             field_schema["exclusiveMaximum"] = True
 
 
-class Regex(object):
+class Regex:
     """Validator for regular expressions."""
 
     FLAGS = {
@@ -126,7 +126,7 @@ class Regex(object):
         field_schema["pattern"] = utilities.convert_python_regex_to_ecma(self.pattern, self.flags)
 
 
-class Length(object):
+class Length:
     """Validator for length."""
 
     def __init__(self, minimum_value: int = None, maximum_value: int = None) -> None:
@@ -171,7 +171,7 @@ class Length(object):
             field_schema["maxLength"] = self.maximum_value
 
 
-class Enum(object):
+class Enum:
     """Validator for enums."""
 
     def __init__(self, *choices: Any) -> None:

--- a/clearml/backend_api/session/token_manager.py
+++ b/clearml/backend_api/session/token_manager.py
@@ -9,7 +9,7 @@ import six
 
 
 @six.add_metaclass(ABCMeta)
-class TokenManager(object):
+class TokenManager:
     @property
     def token_expiration_threshold_sec(self) -> int:
         return self.__token_expiration_threshold_sec

--- a/clearml/backend_config/bucket_config.py
+++ b/clearml/backend_config/bucket_config.py
@@ -24,7 +24,7 @@ def _url_stripper(bucket: str) -> str:
 
 
 @attrs
-class S3BucketConfig(object):
+class S3BucketConfig:
     """Configuration for an S3 bucket"""
     bucket = attrib(type=str, converter=_url_stripper, default="")
     subdir = attrib(type=str, converter=_url_stripper, default="")
@@ -94,7 +94,7 @@ BucketConfig = S3BucketConfig
 
 
 @six.add_metaclass(abc.ABCMeta)
-class BaseBucketConfigurations(object):
+class BaseBucketConfigurations:
     def __init__(self, buckets: Optional[List[Any]] = None, *_: Any, **__: Any) -> None:
         self._buckets = buckets or []
         self._prefixes = None
@@ -270,7 +270,7 @@ BucketConfigurations = S3BucketConfigurations
 
 
 @attrs
-class GSBucketConfig(object):
+class GSBucketConfig:
     bucket = attrib(type=str)
     subdir = attrib(type=str, converter=_url_stripper, default="")
     project = attrib(type=str, default=None)
@@ -379,7 +379,7 @@ class GSBucketConfigurations(BaseBucketConfigurations):
 
 
 @attrs
-class AzureContainerConfig(object):
+class AzureContainerConfig:
     account_name = attrib(type=str)
     account_key = attrib(type=str)
     container_name = attrib(type=str, default=None)
@@ -395,7 +395,7 @@ class AzureContainerConfig(object):
         return self.account_name and self.container_name
 
 
-class AzureContainerConfigurations(object):
+class AzureContainerConfigurations:
     def __init__(
         self,
         container_configs: List[AzureContainerConfig] = None,

--- a/clearml/backend_config/config.py
+++ b/clearml/backend_config/config.py
@@ -61,7 +61,7 @@ class ConfigEntry(Entry):
         log.error(message.capitalize())
 
 
-class Config(object):
+class Config:
     # used in place of None in Config.get as default value because None is a valid value
     _MISSING = object()
 

--- a/clearml/backend_config/defs.py
+++ b/clearml/backend_config/defs.py
@@ -38,7 +38,7 @@ CONFIG_VERBOSE = EnvEntry("CLEARML_CONFIG_VERBOSE", type=bool)
 """Control verbose configuration loading"""
 
 
-class Environment(object):
+class Environment:
     """Supported environment names"""
 
     default = "default"

--- a/clearml/backend_config/entry.py
+++ b/clearml/backend_config/entry.py
@@ -17,7 +17,7 @@ Converter = Callable[[Any], Any]
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Entry(object):
+class Entry:
     """
     Configuration entry definition
     """

--- a/clearml/backend_interface/logger.py
+++ b/clearml/backend_interface/logger.py
@@ -8,7 +8,7 @@ from ..config import running_remotely, config, DEBUG_SIMULATE_REMOTE_TASK
 from ..utilities.process.mp import ForkSafeRLock
 
 
-class StdStreamPatch(object):
+class StdStreamPatch:
     _stdout_proxy = None
     _stderr_proxy = None
     _stdout_original_write = None
@@ -176,7 +176,7 @@ class StdStreamPatch(object):
         return sys.stderr._original_write(*args, **kwargs)  # noqa
 
 
-class HandlerFormat(object):
+class HandlerFormat:
     def __init__(self, logger: logging.Logger) -> None:
         self._logger = logger
 
@@ -196,7 +196,7 @@ class HandlerFormat(object):
         return msg
 
 
-class PrintPatchLogger(object):
+class PrintPatchLogger:
     """
     Allowed patching a stream into the logger.
     Used for capturing and logging stdin and stderr when running in development mode pseudo worker.

--- a/clearml/backend_interface/metrics/events.py
+++ b/clearml/backend_interface/metrics/events.py
@@ -22,7 +22,7 @@ from ...utilities.process.mp import SingletonLock
 
 
 @six.add_metaclass(abc.ABCMeta)
-class MetricsEventAdapter(object):
+class MetricsEventAdapter:
     """
     Adapter providing all the base attributes required by a metrics event and defining an interface used by the
     metrics manager when batching and writing events.
@@ -37,7 +37,7 @@ class MetricsEventAdapter(object):
     _report_inf_warning_iteration = float("inf")
 
     @attrs(cmp=False, slots=True)
-    class FileEntry(object):
+    class FileEntry:
         """File entry used to report on file data that needs to be uploaded prior to sending the event"""
 
         event = attr.attrib()

--- a/clearml/backend_interface/model.py
+++ b/clearml/backend_interface/model.py
@@ -21,7 +21,7 @@ class ModelDoesNotExistError(Exception):
     pass
 
 
-class _StorageUriMixin(object):
+class _StorageUriMixin:
     @property
     def upload_storage_uri(self) -> str:
         """A URI into which models are uploaded"""

--- a/clearml/backend_interface/session.py
+++ b/clearml/backend_interface/session.py
@@ -17,7 +17,7 @@ class SendError(Exception):
 
 
 @six.add_metaclass(ABCMeta)
-class SessionInterface(object):
+class SessionInterface:
     """Session wrapper interface providing a session property and a send convenience method"""
 
     @property

--- a/clearml/backend_interface/setupuploadmixin.py
+++ b/clearml/backend_interface/setupuploadmixin.py
@@ -10,7 +10,7 @@ from ..backend_config.bucket_config import (
 from ..storage.helper import StorageHelper
 
 
-class SetupUploadMixin(object):
+class SetupUploadMixin:
     log = abstractproperty()
     storage_uri = abstractproperty()
 

--- a/clearml/backend_interface/task/access.py
+++ b/clearml/backend_interface/task/access.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional, Any
 from pathlib2 import Path
 
 
-class AccessMixin(object):
+class AccessMixin:
     """A mixin providing task fields access functionality"""
 
     session = abstractproperty()

--- a/clearml/backend_interface/task/args.py
+++ b/clearml/backend_interface/task/args.py
@@ -23,7 +23,7 @@ from ...binding.args import call_original_argparser
 from ...utilities.proxy_object import get_type_from_basic_type_str
 
 
-class _Arguments(object):
+class _Arguments:
     _prefix_sep = "/"
     # TODO: separate dict and argparse after we add UI support
     _prefix_args = "Args" + _prefix_sep

--- a/clearml/backend_interface/task/development/stop_signal.py
+++ b/clearml/backend_interface/task/development/stop_signal.py
@@ -6,13 +6,13 @@ if TYPE_CHECKING:
     from ....backend_interface import Task
 
 
-class TaskStopReason(object):
+class TaskStopReason:
     stopped = "stopped"
     reset = "reset"
     status_changed = "status_changed"
 
 
-class TaskStopSignal(object):
+class TaskStopSignal:
     enabled = deferred_config("development.support_stopping", False, transform=bool)
 
     _number_of_consecutive_reset_tests = 4

--- a/clearml/backend_interface/task/development/worker.py
+++ b/clearml/backend_interface/task/development/worker.py
@@ -12,7 +12,7 @@ from ....utilities.lowlevel.threads import kill_thread
 from ....utilities.process.mp import SafeEvent
 
 
-class DevWorker(object):
+class DevWorker:
     property_abort_callback_completed = "_abort_callback_completed"
     property_abort_callback_timeout = "_abort_callback_timeout"
     property_abort_poll_freq = "_abort_poll_freq"

--- a/clearml/backend_interface/task/hyperparams.py
+++ b/clearml/backend_interface/task/hyperparams.py
@@ -16,7 +16,7 @@ from ...backend_api import Session
 from ...backend_api.services import tasks
 
 
-class HyperParams(object):
+class HyperParams:
     def __init__(self, task: Any) -> None:
         self.task = task
 

--- a/clearml/backend_interface/task/populate.py
+++ b/clearml/backend_interface/task/populate.py
@@ -16,7 +16,7 @@ from .repo import ScriptInfo
 from ...task import Task
 
 
-class CreateAndPopulate(object):
+class CreateAndPopulate:
     _VCS_SSH_REGEX = (
         "^"
         "(?:(?P<user>{regular}*?)@)?"
@@ -687,7 +687,7 @@ class CreateAndPopulate(object):
         return found_index if found_index < 0 else lines[found_index][0]
 
 
-class CreateFromFunction(object):
+class CreateFromFunction:
     kwargs_section = "kwargs"
     return_section = "return"
     input_artifact_section = "kwargs_artifacts"

--- a/clearml/backend_interface/task/repo/detectors.py
+++ b/clearml/backend_interface/task/repo/detectors.py
@@ -26,7 +26,7 @@ class DetectionError(Exception):
 
 
 @attr.s
-class Result(object):
+class Result:
     """ " Repository information as queried by a detector"""
 
     url = attr.ib(default="")
@@ -42,7 +42,7 @@ class Result(object):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class Detector(object):
+class Detector:
     """Base class for repository detection"""
 
     """
@@ -58,7 +58,7 @@ class Detector(object):
         return get_logger("Repository Detection")
 
     @attr.s
-    class Commands(object):
+    class Commands:
         """ " Repository information as queried by a detector"""
 
         url = attr.ib(default=None, type=list)

--- a/clearml/backend_interface/task/repo/scriptinfo.py
+++ b/clearml/backend_interface/task/repo/scriptinfo.py
@@ -33,7 +33,7 @@ class ScriptInfoError(Exception):
     pass
 
 
-class ScriptRequirements(object):
+class ScriptRequirements:
     _detailed_import_report = deferred_config("development.detailed_import_report", False)
     _max_requirements_size = 512 * 1024
     _packages_remove_version = ("setuptools",)
@@ -320,7 +320,7 @@ class ScriptRequirements(object):
         return _internal(installed_pkgs)
 
 
-class _JupyterObserver(object):
+class _JupyterObserver:
     _thread = None
     _exit_event = None
     _sync_event = None
@@ -648,7 +648,7 @@ class _JupyterObserver(object):
                 pass
 
 
-class ScriptInfo(object):
+class ScriptInfo:
     _sagemaker_metadata_path = "/opt/ml/metadata/resource-metadata.json"
 
     max_diff_size_bytes = 500000
@@ -1493,13 +1493,13 @@ class ScriptInfo(object):
 
 
 @attr.s
-class ScriptInfoResult(object):
+class ScriptInfoResult:
     script = attr.ib(default=None)
     warning_messages = attr.ib(factory=list)
     auxiliary_git_diff = attr.ib(default=None)
 
 
-class _JupyterHistoryLogger(object):
+class _JupyterHistoryLogger:
     _reg_replace_ipython = r"\n([ \t]*)get_ipython\(\)"
     _reg_replace_magic = r"\n([ \t]*)%"
     _reg_replace_bang = r"\n([ \t]*)!"

--- a/clearml/binding/absl_bind.py
+++ b/clearml/binding/absl_bind.py
@@ -7,7 +7,7 @@ from ..backend_interface.task.args import _Arguments
 from ..config import running_remotely
 
 
-class PatchAbsl(object):
+class PatchAbsl:
     _original_DEFINE_flag = None
     _original_FLAGS_parse_call = None
     _current_task = None

--- a/clearml/binding/artifacts.py
+++ b/clearml/binding/artifacts.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     import pandas
 
 
-class Artifact(object):
+class Artifact:
     """
     Read-Only Artifact object
     """
@@ -267,7 +267,7 @@ class Artifact(object):
         )
 
 
-class Artifacts(object):
+class Artifacts:
     max_preview_size_bytes = 65536
 
     _flush_frequency_sec = 300.0

--- a/clearml/binding/environ_bind.py
+++ b/clearml/binding/environ_bind.py
@@ -12,7 +12,7 @@ from ..config import TASK_LOG_ENVIRONMENT, running_remotely, config
 from ..utilities.process.mp import BackgroundMonitor
 
 
-class EnvironmentBind(object):
+class EnvironmentBind:
     _current_task = None
     _environment_section = "Environment"
     __patched = False
@@ -71,7 +71,7 @@ class EnvironmentBind(object):
         cls._current_task.connect(env_param, cls._environment_section)
 
 
-class SimpleQueueWrapper(object):
+class SimpleQueueWrapper:
     def __init__(self, task: Any, simple_queue: Any) -> None:
         self.__current_task = task
         self.__simple_queue = simple_queue
@@ -96,7 +96,7 @@ class SimpleQueueWrapper(object):
         return getattr(self.__simple_queue, attr)
 
 
-class PatchOsFork(object):
+class PatchOsFork:
     _original_fork = None
     _registered_fork_callbacks = False
     _current_task = None

--- a/clearml/binding/fire_bind.py
+++ b/clearml/binding/fire_bind.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     import fire
 
 
-class SimpleNamespace(object):
+class SimpleNamespace:
     def __init__(self, **kwargs: Any) -> None:
         self.__dict__.update(kwargs)
 

--- a/clearml/binding/frameworks/__init__.py
+++ b/clearml/binding/frameworks/__init__.py
@@ -51,12 +51,12 @@ def _patched_call_no_recursion_guard(original_fn: Callable, patched_fn: Callable
     return _inner_patch
 
 
-class _Empty(object):
+class _Empty:
     def __init__(self) -> None:
         self.trains_in_model = None
 
 
-class WeightsFileHandler(object):
+class WeightsFileHandler:
     # _model_out_store_lookup = {}
     # _model_in_store_lookup = {}
     _model_store_lookup_lock = threading.Lock()
@@ -74,7 +74,7 @@ class WeightsFileHandler(object):
         save = "save"
         load = "load"
 
-    class ModelInfo(object):
+    class ModelInfo:
         def __init__(
             self,
             model: Optional[Model],

--- a/clearml/binding/frameworks/base_bind.py
+++ b/clearml/binding/frameworks/base_bind.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 @six.add_metaclass(ABCMeta)
-class PatchBaseModelIO(object):
+class PatchBaseModelIO:
     """
     Base class for patched models
 

--- a/clearml/binding/frameworks/fastai_bind.py
+++ b/clearml/binding/frameworks/fastai_bind.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     import fastai
 
 
-class PatchFastai(object):
+class PatchFastai:
     @staticmethod
     def update_current_task(task: Any, **_: Any) -> None:
         if fastai is None:
@@ -38,7 +38,7 @@ class PatchFastai(object):
             pass
 
 
-class PatchFastaiV1(object):
+class PatchFastaiV1:
     __metrics_names = {}
     __gradient_hist_helpers = {}
     _current_task = None
@@ -199,7 +199,7 @@ class PatchFastaiV1(object):
             pass
 
 
-class PatchFastaiV2(object):
+class PatchFastaiV2:
     _current_task = None
     __patched = False
 

--- a/clearml/binding/frameworks/tensorflow_bind.py
+++ b/clearml/binding/frameworks/tensorflow_bind.py
@@ -32,7 +32,7 @@ except ImportError:
     pass
 
 
-class TensorflowBinding(object):
+class TensorflowBinding:
     @classmethod
     def update_current_task(
         cls,
@@ -56,7 +56,7 @@ class TensorflowBinding(object):
             PatchTensorflow2ModelIO.update_current_task(task)
 
 
-class IsTensorboardInit(object):
+class IsTensorboardInit:
     _tensorboard_initialized = False
 
     @classmethod
@@ -78,7 +78,7 @@ class IsTensorboardInit(object):
 
 
 # noinspection PyProtectedMember
-class WeightsGradientHistHelper(object):
+class WeightsGradientHistHelper:
     def __init__(
         self,
         logger: Any,
@@ -271,7 +271,7 @@ class WeightsGradientHistHelper(object):
 
 
 # noinspection PyMethodMayBeStatic,PyProtectedMember,SpellCheckingInspection
-class EventTrainsWriter(object):
+class EventTrainsWriter:
     """
     TF SummaryWriter implementation that converts the tensorboard's summary into
     ClearML events and reports the events (metrics) for an ClearML task (logger).
@@ -1008,7 +1008,7 @@ class EventTrainsWriter(object):
 
 
 # noinspection PyCallingNonCallable
-class ProxyEventsWriter(object):
+class ProxyEventsWriter:
     def __init__(self, events: Any) -> None:
         IsTensorboardInit.set_tensorboard_used()
         self._events = events
@@ -1058,7 +1058,7 @@ class ProxyEventsWriter(object):
 
 
 # noinspection PyPep8Naming
-class PatchSummaryToEventTransformer(object):
+class PatchSummaryToEventTransformer:
     _current_task = None
     __original_getattribute = None
     __original_getattributeX = None
@@ -1273,7 +1273,7 @@ class PatchSummaryToEventTransformer(object):
         return get_base(self, attr)
 
 
-class _ModelAdapter(object):
+class _ModelAdapter:
     """Model adapter which extends the save and save_weights methods of a Keras Model instance"""
 
     _model: Any = None
@@ -1313,7 +1313,7 @@ class _ModelAdapter(object):
             self._logger.error(str(ex))
 
 
-class PatchModelCheckPointCallback(object):
+class PatchModelCheckPointCallback:
     _current_task = None
     __original_getattribute = None
     __patched = False
@@ -1420,7 +1420,7 @@ class PatchModelCheckPointCallback(object):
 
 
 # noinspection PyProtectedMember,PyUnresolvedReferences
-class PatchTensorFlowEager(object):
+class PatchTensorFlowEager:
     _current_task = None
     __original_fn_scalar = None
     __original_fn_hist = None
@@ -1825,7 +1825,7 @@ class PatchTensorFlowEager(object):
 
 
 # noinspection PyPep8Naming,SpellCheckingInspection
-class PatchKerasModelIO(object):
+class PatchKerasModelIO:
     _current_task = None
     __patched_keras = None
     __patched_tensorflow = None
@@ -2278,7 +2278,7 @@ class PatchKerasModelIO(object):
         return self._current_task
 
 
-class PatchTensorflowModelIO(object):
+class PatchTensorflowModelIO:
     _current_task = None
     __patched = None
 
@@ -2613,7 +2613,7 @@ class PatchTensorflowModelIO(object):
         return model
 
 
-class PatchTensorflow2ModelIO(object):
+class PatchTensorflow2ModelIO:
     _current_task = None
     __patched = None
 

--- a/clearml/binding/hydra_bind.py
+++ b/clearml/binding/hydra_bind.py
@@ -10,7 +10,7 @@ from ..config import running_remotely, get_remote_task_id, DEV_TASK_NO_REUSE
 from ..debugging.log import LoggerRoot
 
 
-class PatchHydra(object):
+class PatchHydra:
     _original_run_job = None
     _original_hydra_run = None
     _allow_omegaconf_edit = None

--- a/clearml/binding/import_bind.py
+++ b/clearml/binding/import_bind.py
@@ -13,7 +13,7 @@ else:
     import builtins
 
 
-class PostImportHookPatching(object):
+class PostImportHookPatching:
     _patched = False
     _post_import_hooks = defaultdict(list)
 

--- a/clearml/binding/joblib_bind.py
+++ b/clearml/binding/joblib_bind.py
@@ -18,7 +18,7 @@ from ..utilities.lowlevel.file_access import (
 )
 
 
-class PatchedJoblib(object):
+class PatchedJoblib:
     _patched_joblib = False
     _patched_sk_joblib = False
     _current_task = None

--- a/clearml/binding/jsonargs_bind.py
+++ b/clearml/binding/jsonargs_bind.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from jsonargparse import ArgumentParser
 
 
-class PatchJsonArgParse(object):
+class PatchJsonArgParse:
     namespace_type = "jsonargparse_namespace"
     path_type = "jsonargparse_path"
     _args = {}

--- a/clearml/binding/matplotlib_bind.py
+++ b/clearml/binding/matplotlib_bind.py
@@ -40,7 +40,7 @@ class PatchedMatplotlib:
     _logger_started_reporting = False
     _matplotlib_reported_titles = set()
 
-    class _PatchWarnings(object):
+    class _PatchWarnings:
         def __init__(self) -> None:
             pass
 

--- a/clearml/config/__init__.py
+++ b/clearml/config/__init__.py
@@ -18,7 +18,7 @@ from ..backend_config.bucket_config import S3BucketConfigurations
 from ..utilities.proxy_object import LazyEvalWrapper
 
 
-class ConfigWrapper(object):
+class ConfigWrapper:
     _config = None
 
     @classmethod
@@ -47,7 +47,7 @@ class ConfigWrapper(object):
             cls._config = value
 
 
-class ConfigSDKWrapper(object):
+class ConfigSDKWrapper:
     _config_sdk = None
 
     @classmethod

--- a/clearml/config/cache.py
+++ b/clearml/config/cache.py
@@ -8,7 +8,7 @@ from . import running_remotely
 from .defs import SESSION_CACHE_FILE
 
 
-class SessionCache(object):
+class SessionCache:
     """
     Handle SDK session cache.
     TODO: Improve error handling to something like "except (FileNotFoundError, PermissionError, JSONDecodeError)"

--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -77,7 +77,7 @@ if TYPE_CHECKING:
 
 
 @attrs
-class FileEntry(object):
+class FileEntry:
     relative_path = attrib(default=None, type=str)
     hash = attrib(default=None, type=str)
     parent_dataset_id = attrib(default=None, type=str)
@@ -100,7 +100,7 @@ class FileEntry(object):
 
 
 @attrs
-class LinkEntry(object):
+class LinkEntry:
     link = attrib(default=None, type=str)
     relative_path = attrib(default=None, type=str)
     parent_dataset_id = attrib(default=None, type=str)
@@ -116,7 +116,7 @@ class LinkEntry(object):
         )
 
 
-class Dataset(object):
+class Dataset:
     __private_magic = 42 * 1337
     __state_entry_name = "state"
     __default_data_entry_name = "data"

--- a/clearml/debugging/log.py
+++ b/clearml/debugging/log.py
@@ -96,7 +96,7 @@ class _LevelRangeFilter(logging.Filter):
         return self.min_level <= record.levelno <= self.max_level
 
 
-class LoggerRoot(object):
+class LoggerRoot:
     __base_logger = None
 
     @classmethod
@@ -270,7 +270,7 @@ def get_null_logger(name: Optional[str] = None) -> PickledLogger:
     return PickledLogger.wrapper(log, func=get_null_logger, name=name)
 
 
-class TqdmLog(object):
+class TqdmLog:
     """Tqdm (progressbar) wrapped logging class"""
 
     class _TqdmIO(BytesIO):

--- a/clearml/debugging/timer.py
+++ b/clearml/debugging/timer.py
@@ -6,7 +6,7 @@ from typing import Callable, Optional, Dict, List, Any
 import six
 
 
-class Timer(object):
+class Timer:
     """A class implementing a simple timer, with a reset option"""
 
     def __init__(self) -> None:
@@ -66,7 +66,7 @@ class Timer(object):
         return self.toc(average=average)
 
 
-class TimersMixin(object):
+class TimersMixin:
     def __init__(self) -> None:
         self._timers = {}
 

--- a/clearml/debugging/trace.py
+++ b/clearml/debugging/trace.py
@@ -78,7 +78,7 @@ def _traced_call_method(name: str, fnc: Callable) -> Callable:
 
 
 def _traced_call_cls(name: str, fnc: Callable) -> Callable:
-    class WrapperClass(object):
+    class WrapperClass:
         @classmethod
         def _traced_call_int(cls, *args: Any, **kwargs: Any) -> Any:
             _log_stderr(name, fnc, args, kwargs, False)
@@ -96,7 +96,7 @@ def _traced_call_cls(name: str, fnc: Callable) -> Callable:
 
 
 def _traced_call_static(name: str, fnc: Callable) -> Callable:
-    class WrapperStatic(object):
+    class WrapperStatic:
         @staticmethod
         def _traced_call_int(*args: Any, **kwargs: Any) -> Any:
             _log_stderr(name, fnc, args, kwargs, False)

--- a/clearml/logger.py
+++ b/clearml/logger.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from matplotlib import pyplot  # noqa
 
 
-class Logger(object):
+class Logger:
     """
     The ``Logger`` class is the ClearML console log and metric statistics interface, and contains methods for explicit
     reporting.
@@ -1266,7 +1266,7 @@ class Logger(object):
         :return: a ContextManager
         """
 
-        class _LoggingContext(object):
+        class _LoggingContext:
             def __init__(self, a_logger: Logger) -> None:
                 self.logger = a_logger
 

--- a/clearml/model.py
+++ b/clearml/model.py
@@ -171,7 +171,7 @@ class Framework(Options):
 
 
 @six.add_metaclass(abc.ABCMeta)
-class BaseModel(object):
+class BaseModel:
     # noinspection PyProtectedMember
     _archived_tag = _Task.archived_tag
     _package_tag = "package"
@@ -2775,6 +2775,6 @@ class OutputModel(BaseModel):
         return Path(self._last_uploaded_url or self.url).name
 
 
-class Waitable(object):
+class Waitable:
     def wait(self, *_: Any, **__: Any) -> bool:
         return True

--- a/clearml/storage/cache.py
+++ b/clearml/storage/cache.py
@@ -17,7 +17,7 @@ from ..utilities.locks.exceptions import LockException
 from ..utilities.locks.utils import Lock as FileLock
 
 
-class CacheManager(object):
+class CacheManager:
     __cache_managers = {}
     _default_cache_file_limit = deferred_config("storage.cache.default_cache_manager_size", 100)
     _storage_manager_folder = "storage_manager"
@@ -29,7 +29,7 @@ class CacheManager(object):
     _lockfile_prefix = ".lock."
     _lockfile_suffix = ".clearml"
 
-    class CacheContext(object):
+    class CacheContext:
         _folder_locks: Dict[str, FileLock] = dict()
         _lockfile_at_exit_cb = None
 

--- a/clearml/storage/callbacks.py
+++ b/clearml/storage/callbacks.py
@@ -11,7 +11,7 @@ except ImportError:
     tqdm = None
 
 
-class ProgressReport(object):
+class ProgressReport:
     report_upload_chunk_size_mb = None
     report_download_chunk_size_mb = None
 

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -229,7 +229,7 @@ class _HttpDriver(_Driver):
 
     schemes = ("http", "https")
 
-    class _Container(object):
+    class _Container:
         _default_backend_session = None
 
         def __init__(self, name: str, retries: int = 5, **kwargs: Any) -> None:
@@ -268,7 +268,7 @@ class _HttpDriver(_Driver):
             if self._should_attach_auth_header():
                 return self._default_backend_session.add_auth_headers({})
 
-    class _HttpSessionHandle(object):
+    class _HttpSessionHandle:
         def __init__(
             self,
             url: str,
@@ -468,7 +468,7 @@ class _HttpDriver(_Driver):
             return False
 
 
-class _Stream(object):
+class _Stream:
     encoding = None
     mode = "rw"
     name = ""
@@ -588,7 +588,7 @@ class _Boto3Driver(_Driver):
 
     _bucket_location_failure_reported = set()
 
-    class _Container(object):
+    class _Container:
         _creation_lock = ForkSafeRLock()
 
         def __init__(self, name: str, cfg: S3BucketConfig) -> None:
@@ -614,7 +614,7 @@ class _Boto3Driver(_Driver):
                 self.bucket = self.resource.Bucket(bucket_name)
 
     @attrs
-    class ListResult(object):
+    class ListResult:
         name = attrib(default=None)
         size = attrib(default=None)
 
@@ -1031,7 +1031,7 @@ class _GoogleCloudStorageDriver(_Driver):
     scheme = "gs"
     scheme_prefix = str(furl(scheme=scheme, netloc=""))
 
-    class _Container(object):
+    class _Container:
         def __init__(self, name: str, cfg: Any) -> None:
             try:
                 from google.cloud import storage  # noqa
@@ -1229,7 +1229,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
     _containers = {}
     _max_connections = deferred_config("azure.storage.max_connections", 0)
 
-    class _Container(object):
+    class _Container:
         def __init__(
             self,
             name: str,
@@ -1422,7 +1422,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
             return self.__blob_service
 
     @attrs
-    class _Object(object):
+    class _Object:
         container = attrib()
         blob_name = attrib()
         content_length = attrib()
@@ -1676,7 +1676,7 @@ class _FileStorageDriver(_Driver):
     IGNORE_FOLDERS = [".lock", ".hash"]
     Object = namedtuple("Object", ["name", "size", "extra", "driver", "container", "hash", "meta_data"])
 
-    class _Container(object):
+    class _Container:
         def __init__(self, name: str, extra: dict, driver: Any) -> None:
             self.name = name
             self.extra = extra
@@ -2244,7 +2244,7 @@ class _FileStorageDriver(_Driver):
         return os.path.isfile(object_name)
 
 
-class _StorageHelper(object):
+class _StorageHelper:
     """Storage helper.
     Used by the entire system to download/upload files.
     Supports both local and remote files (currently local files, network-mapped files, HTTP/S and Amazon S3)
@@ -2258,7 +2258,7 @@ class _StorageHelper(object):
         return get_logger("storage")
 
     @attrs
-    class _PathSubstitutionRule(object):
+    class _PathSubstitutionRule:
         registered_prefix = attrib(type=str)
         local_prefix = attrib(type=str)
         replace_windows_sep = attrib(type=bool)
@@ -2305,7 +2305,7 @@ class _StorageHelper(object):
 
             return rules_list
 
-    class _UploadData(object):
+    class _UploadData:
         @property
         def src_path(self) -> str:
             return self._src_path
@@ -3581,10 +3581,10 @@ class StorageHelper(_StorageHelper):
         transform=bool,
     )
 
-    class CacheConfigs(object):
+    class CacheConfigs:
         configs = {}
 
-        class Defaults(object):
+        class Defaults:
             cache_name = None
             cache_base_dir = None
             cleanup_seconds_threshold = None

--- a/clearml/storage/manager.py
+++ b/clearml/storage/manager.py
@@ -17,7 +17,7 @@ from ..config import deferred_config
 from ..debugging.log import LoggerRoot
 
 
-class StorageManager(object):
+class StorageManager:
     """
     StorageManager is helper interface for downloading & uploading files to supported remote storage
     Support remote servers: http(s)/S3/GS/Azure/File-System-Folder

--- a/clearml/task.py
+++ b/clearml/task.py
@@ -225,7 +225,7 @@ class Task(_Task):
     }
     _external_endpoint_host_tcp_port_mapping = {"tcp_host_mapping": "_external_host_tcp_port_mapping"}
 
-    class _ConnectedParametersType(object):
+    class _ConnectedParametersType:
         argparse = "argument_parser"
         dictionary = "dictionary"
         task_parameters = "task_parameters"

--- a/clearml/task_parameters.py
+++ b/clearml/task_parameters.py
@@ -124,7 +124,7 @@ class _AttrsMeta(type):
 
 
 @six.add_metaclass(_AttrsMeta)
-class TaskParameters(object):
+class TaskParameters:
     """
     Base class for task parameters.
 

--- a/clearml/utilities/async_manager.py
+++ b/clearml/utilities/async_manager.py
@@ -7,7 +7,7 @@ import six
 from .process.mp import SingletonLock
 
 
-class AsyncManagerMixin(object):
+class AsyncManagerMixin:
     _async_results_lock = SingletonLock()
     # per pid (process) list of async jobs (support for sub-processes forking)
     _async_results = {}

--- a/clearml/utilities/attrs.py
+++ b/clearml/utilities/attrs.py
@@ -13,7 +13,7 @@ except ImportError:
     attr_version = attr.__version__
 
 
-class attrs(object):
+class attrs:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         if any(x in kwargs for x in ("eq", "order")):
             raise RuntimeError("Only `cmp` is supported for attr.attrs, not `eq` or `order`")

--- a/clearml/utilities/check_updates.py
+++ b/clearml/utilities/check_updates.py
@@ -11,7 +11,7 @@ from ..backend_api.session import Session
 from ..backend_config import EnvEntry
 
 
-class CheckPackageUpdates(object):
+class CheckPackageUpdates:
     _package_version_checked = False
 
     @classmethod

--- a/clearml/utilities/deferred.py
+++ b/clearml/utilities/deferred.py
@@ -6,9 +6,9 @@ import attr
 import six
 
 
-class DeferredExecutionPool(object):
+class DeferredExecutionPool:
     @attr.s
-    class _DeferredAction(object):
+    class _DeferredAction:
         method = attr.ib()
         args = attr.ib()
         kwargs = attr.ib()
@@ -49,7 +49,7 @@ class ParameterizedDefaultDict(dict):
         return self[key]
 
 
-class DeferredExecution(object):
+class DeferredExecution:
     def __init__(self, pool_cls: type = DeferredExecutionPool) -> None:
         self._pools = ParameterizedDefaultDict(pool_cls)
 

--- a/clearml/utilities/enum.py
+++ b/clearml/utilities/enum.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Any
 
 
-class EnumOptions(object):
+class EnumOptions:
     """Base class for enum-like classes using class-attributes with string values to represent enum key/value pairs"""
 
     __cache = None
@@ -22,7 +22,7 @@ class EnumOptions(object):
         return cls.__cache
 
 
-class Options(object):
+class Options:
     """Base class for an Options class which allow getting all class properties as a key/value mapping"""
 
     @classmethod

--- a/clearml/utilities/io_manager.py
+++ b/clearml/utilities/io_manager.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 
-class IOCallsManager(object):
+class IOCallsManager:
     def __init__(self) -> None:
         self.threads_io = {}
 

--- a/clearml/utilities/locks/utils.py
+++ b/clearml/utilities/locks/utils.py
@@ -68,7 +68,7 @@ def open_atomic(filename: str, binary: bool = True) -> Generator[tempfile._Tempo
             pass
 
 
-class Lock(object):
+class Lock:
     def __init__(
         self,
         filename: str,

--- a/clearml/utilities/parallel.py
+++ b/clearml/utilities/parallel.py
@@ -15,7 +15,7 @@ from ..debugging.log import LoggerRoot
 from ..storage.util import format_size
 
 
-class _DeferredClass(object):
+class _DeferredClass:
     __slots__ = ("__queue", "__future_caller", "__future_func")
 
     def __init__(self, a_future_caller: Any, future_func: str) -> None:
@@ -98,7 +98,7 @@ class _DeferredClass(object):
         return _caller
 
 
-class FutureTaskCaller(object):
+class FutureTaskCaller:
     """
     FutureTaskCaller is used to create a class via a functions async, in another thread.
 
@@ -215,12 +215,12 @@ class FutureTaskCaller(object):
         return self.__deferred_bkg_class
 
 
-class ParallelZipper(object):
+class ParallelZipper:
     """
     Used to zip multiple files in zip chunks of a particular size, all in parallel
     """
 
-    class ZipperObject(object):
+    class ZipperObject:
         def __init__(
             self,
             chunk_size: int,

--- a/clearml/utilities/plotly_reporter.py
+++ b/clearml/utilities/plotly_reporter.py
@@ -88,7 +88,7 @@ def _to_np_array(value: Any) -> np.ndarray:
 
 
 @attrs
-class SeriesInfo(object):
+class SeriesInfo:
     name = attrib(type=str)
     data = attrib(type=np.ndarray, converter=_to_np_array)
     labels = attrib(default=None)

--- a/clearml/utilities/process/exit_hooks.py
+++ b/clearml/utilities/process/exit_hooks.py
@@ -10,7 +10,7 @@ import six
 from ...logger import Logger
 
 
-class ExitHooks(object):
+class ExitHooks:
     _orig_exit = None
     _orig_exc_handler = None
     remote_user_aborted = False

--- a/clearml/utilities/process/mp.py
+++ b/clearml/utilities/process/mp.py
@@ -39,7 +39,7 @@ except ImportError:
         return multiprocessing
 
 
-class _ForkSafeThreadSyncObject(object):
+class _ForkSafeThreadSyncObject:
     __process_lock = get_context("fork" if sys.platform == "linux" else "spawn").Lock()
 
     @classmethod
@@ -212,7 +212,7 @@ class ForkQueue(_ForkSafeThreadSyncObject):
         return self._sync.close()
 
 
-class ThreadCalls(object):
+class ThreadCalls:
     def __init__(self) -> None:
         self._queue = ForkQueue()
         self._thread = Thread(target=self._worker)
@@ -262,7 +262,7 @@ class ThreadCalls(object):
         self._thread = None
 
 
-class SingletonThreadPool(object):
+class SingletonThreadPool:
     __thread_pool = None
     __thread_pool_pid = None
 
@@ -285,7 +285,7 @@ class SingletonThreadPool(object):
         return cls.__thread_pool and cls.__thread_pool_pid == os.getpid() and cls.__thread_pool.is_alive()
 
 
-class SafeQueue(object):
+class SafeQueue:
     """
     Many writers Single Reader multiprocessing safe Queue
     """
@@ -450,7 +450,7 @@ class SafeQueue(object):
         self._send(header + buf)
 
 
-class SafeEvent(object):
+class SafeEvent:
     __thread_pool = SingletonThreadPool()
 
     def __init__(self) -> None:
@@ -512,7 +512,7 @@ class SingletonLock(AbstractContextManager):
         self.release()
 
 
-class BackgroundMonitor(object):
+class BackgroundMonitor:
     # If we need multiple monitoring contexts (i.e. subprocesses) this will become a dict
     _main_process = None
     _main_process_proc_obj = None

--- a/clearml/utilities/proxy_object.py
+++ b/clearml/utilities/proxy_object.py
@@ -115,7 +115,7 @@ class ProxyDictPreWrite(dict):
         )
 
 
-class StubObject(object):
+class StubObject:
     def __call__(self, *args: Any, **kwargs: Any) -> "StubObject":
         return self
 

--- a/clearml/utilities/py3_interop.py
+++ b/clearml/utilities/py3_interop.py
@@ -7,7 +7,7 @@ import six
 
 
 @six.add_metaclass(abc.ABCMeta)
-class AbstractContextManager(object):
+class AbstractContextManager:
     """An abstract base class for context managers. Supported in contextlib from python 3.6 and up"""
 
     def __enter__(self) -> "AbstractContextManager":

--- a/clearml/utilities/version.py
+++ b/clearml/utilities/version.py
@@ -20,7 +20,7 @@ class InvalidVersion(ValueError):
 
 
 @attrs
-class _Version(object):
+class _Version:
     epoch = attrib()
     release = attrib()
     dev = attrib()
@@ -29,7 +29,7 @@ class _Version(object):
     local = attrib()
 
 
-class _BaseVersion(object):
+class _BaseVersion:
     def __init__(self, key: Any) -> None:
         self._key = key
 

--- a/examples/frameworks/fire/fire_class_cmd.py
+++ b/examples/frameworks/fire/fire_class_cmd.py
@@ -5,7 +5,7 @@ from clearml import Task
 import fire
 
 
-class BrokenCalculator(object):
+class BrokenCalculator:
     def __init__(self, offset=1):
         self._offset = offset
 

--- a/examples/frameworks/fire/fire_grouping_cmd.py
+++ b/examples/frameworks/fire/fire_grouping_cmd.py
@@ -5,12 +5,12 @@ from clearml import Task
 import fire
 
 
-class Other(object):
+class Other:
     def status(self):
         return "Other"
 
 
-class IngestionStage(object):
+class IngestionStage:
     def __init__(self):
         self.other = Other()
 
@@ -21,7 +21,7 @@ class IngestionStage(object):
         return hello_str
 
 
-class DigestionStage(object):
+class DigestionStage:
     def run(self, volume=1):
         return " ".join(["Burp!"] * volume)
 
@@ -29,7 +29,7 @@ class DigestionStage(object):
         return "Satiated."
 
 
-class Pipeline(object):
+class Pipeline:
     def __init__(self):
         self.ingestion = IngestionStage()
         self.digestion = DigestionStage()

--- a/examples/frameworks/fire/fire_object_cmd.py
+++ b/examples/frameworks/fire/fire_object_cmd.py
@@ -5,7 +5,7 @@ from clearml import Task
 import fire
 
 
-class Calculator(object):
+class Calculator:
     def add(self, x, y):
         return x + y
 

--- a/examples/frameworks/pytorch/pytorch_distributed_example.py
+++ b/examples/frameworks/pytorch/pytorch_distributed_example.py
@@ -45,7 +45,7 @@ class Net(nn.Module):
         return output
 
 
-class Partition(object):
+class Partition:
     """ Dataset partitioning helper """
     def __init__(self, data, index):
         self.data = data
@@ -59,7 +59,7 @@ class Partition(object):
         return self.data[data_idx]
 
 
-class DataPartitioner(object):
+class DataPartitioner:
     def __init__(self, data, sizes=(0.7, 0.2, 0.1), seed=1234):
         self.data = data
         self.partitions = []


### PR DESCRIPTION
## Related issue
#1533  

## Description
Some files were omitted because they come from auto-generated code that we don't want to touch to avoid diffs that revert the changes. Those are
- `clearml/utilities/gpu/gpustat.py`
- `clearml/utilities/gpu/pynvml.py`
- `clearml/utilities/pigar/__main__.py`
- `clearml/utilities/pigar/reqs.py`
- `clearml/utilities/pigar/unpack.py`
- `clearml/utilities/pigar/utils.py`
- `clearml/utilities/plotlympl/mplexporter/exporter.py`
- `clearml/utilities/plotlympl/mplexporter/renderers/base.py`
- `clearml/utilities/plotlympl/mplexporter/renderers/vega_renderer.py`
- `clearml/utilities/pyhocon/config_parser.py`
- `clearml/utilities/pyhocon/config_tree.py`
- `clearml/utilities/pyhocon/converter.py`
- `clearml/utilities/requests_toolbelt/multipart/decoder.py`
- `clearml/utilities/requests_toolbelt/multipart/encoder.py`

There's a lot of changes. However, literally all the diff'ed lines are of the form
```py
# Before
class Example(object):
    pass
    
# After
class Example:
    pass
```