### PR TITLE
Fix race condition with not using incremental logging config

### DIFF
--- a/clearml/config/default/logging.conf
+++ b/clearml/config/default/logging.conf
@@ -1,6 +1,7 @@
 {
     version: 1
     disable_existing_loggers: 0
+    incremental: 1
     loggers {
         clearml {
             level: INFO


### PR DESCRIPTION
Without this fix, not using incremental logging config ends up removing all handlers from the clearml base logger (if the logger was set up before the logging dictConfig was applied) because of that race condition
