### PR TITLE
gh-1541: Replace `six.string_types` by `str`

### DIFF
--- a/clearml/automation/controller.py
+++ b/clearml/automation/controller.py
@@ -5,7 +5,6 @@ import json
 import os
 import re
 
-import six
 import warnings
 from copy import copy, deepcopy
 from datetime import datetime
@@ -1709,7 +1708,7 @@ class PipelineController:
 
         :return: The new cloned PipelineController
         """
-        if isinstance(pipeline_controller, six.string_types):
+        if isinstance(pipeline_controller, str):
             pipeline_controller = Task.get_task(task_id=pipeline_controller)
         elif isinstance(pipeline_controller, PipelineController):
             pipeline_controller = pipeline_controller.task
@@ -2671,7 +2670,7 @@ class PipelineController:
                 # steps from tasks the _nodes is till empty, only after deserializing we will have the full DAG)
                 if self._task.running_locally():
                     self.__verify_step_reference(node=self.Node(name=name), step_ref_string=v)
-            elif not isinstance(v, (float, int, bool, six.string_types)):
+            elif not isinstance(v, (float, int, bool, str)):
                 function_input_artifacts[k] = "{}.{}.{}".format(self._task.id, name, k)
                 self._upload_pipeline_artifact(artifact_name="{}.{}".format(name, k), artifact_object=v)
 
@@ -3449,7 +3448,7 @@ class PipelineController:
             for g in pattern.findall(value):
                 # update with actual value
                 new_val = self.__parse_step_reference(g)
-                if not isinstance(new_val, six.string_types):
+                if not isinstance(new_val, str):
                     return new_val
                 updated_value = updated_value.replace(g, new_val, 1)
 
@@ -5371,7 +5370,7 @@ class PipelineDecorator(PipelineController):
                     return
 
         for k, v in kwargs.items():
-            if v is None or isinstance(v, (float, int, bool, six.string_types)):
+            if v is None or isinstance(v, (float, int, bool, str)):
                 _node.parameters["{}/{}".format(CreateFromFunction.kwargs_section, k)] = v
             else:
                 # we need to create an artifact

--- a/clearml/automation/optimization.py
+++ b/clearml/automation/optimization.py
@@ -1992,7 +1992,7 @@ class HyperParameterOptimizer:
                 for k, v in optimizer_kwargs.items()
                 if not isinstance(
                     v,
-                    six.string_types + six.integer_types + (str, float, list, tuple, dict, type(None)),
+                    six.integer_types + (str, float, list, tuple, dict, type(None)),
                 )
             }
             kwargs["optimizer_kwargs"] = {

--- a/clearml/backend_api/schema/action.py
+++ b/clearml/backend_api/schema/action.py
@@ -1,6 +1,5 @@
 import attr
 from attr.validators import and_, instance_of, optional
-from six import string_types
 from typing import Any
 
 # noinspection PyTypeChecker
@@ -24,12 +23,12 @@ class Action:
     log_data = attr.ib(validator=instance_of(bool), default=True)
     log_result_data = attr.ib(validator=instance_of(bool), default=True)
     internal = attr.ib(default=False)
-    allow_roles = attr.ib(default=None, validator=optional(sequence_of(string_types)))
+    allow_roles = attr.ib(default=None, validator=optional(sequence_of(str)))
     request = attr.ib(validator=optional(instance_of(dict)), default=None)
     batch_request = attr.ib(validator=optional(instance_of(dict)), default=None)
     response = attr.ib(validator=optional(instance_of(dict)), default=None)
     method = attr.ib(default=None)
     description = attr.ib(
         default=None,
-        validator=optional(instance_of(string_types)),
+        validator=optional(instance_of(str)),
     )

--- a/clearml/backend_api/schema/service.py
+++ b/clearml/backend_api/schema/service.py
@@ -3,7 +3,6 @@ import re
 from typing import Dict, Set, Any
 
 import attr
-import six
 
 from ...utilities.pyhocon import ConfigTree
 from .action import Action
@@ -116,7 +115,7 @@ class Service:
         refs = set()
         if isinstance(s, dict):
             for k, v in s.items():
-                if isinstance(v, six.string_types):
+                if isinstance(v, str):
                     m = self.__jsonschema_ref_ex.match(v)
                     if m:
                         refs.add(m.group(1))

--- a/clearml/backend_api/session/jsonmodels/builders.py
+++ b/clearml/backend_api/session/jsonmodels/builders.py
@@ -5,8 +5,6 @@ from __future__ import absolute_import
 from collections import defaultdict
 from typing import Any
 
-import six
-
 from . import errors
 from .fields import NotSet
 
@@ -136,7 +134,7 @@ class PrimitiveBuilder(Builder):
 
     def build(self) -> dict:
         schema = {}
-        if issubclass(self.type, six.string_types):
+        if issubclass(self.type, str):
             obj_type = "string"
         elif issubclass(self.type, bool):
             obj_type = "boolean"

--- a/clearml/backend_api/session/jsonmodels/fields.py
+++ b/clearml/backend_api/session/jsonmodels/fields.py
@@ -2,8 +2,6 @@ import datetime
 import re
 from typing import Union, List, Optional, Type, Iterable, Tuple, Any
 from weakref import WeakKeyDictionary
-
-import six
 from dateutil.parser import parse
 
 from .errors import ValidationError
@@ -142,7 +140,7 @@ class BaseField:
 class StringField(BaseField):
     """String field."""
 
-    types = six.string_types
+    types = (str,)
 
 
 class IntField(BaseField):
@@ -213,7 +211,7 @@ class ListField(BaseField):
 
         types = []
         for type_ in self.items_types:
-            if isinstance(type_, six.string_types):
+            if isinstance(type_, str):
                 types.append(_LazyType(type_))
             else:
                 types.append(type_)
@@ -301,7 +299,7 @@ class EmbeddedField(BaseField):
 
         types = []
         for type_ in model_types:
-            if isinstance(type_, six.string_types):
+            if isinstance(type_, str):
                 types.append(_LazyType(type_))
             else:
                 types.append(type_)

--- a/clearml/backend_api/session/jsonmodels/utilities.py
+++ b/clearml/backend_api/session/jsonmodels/utilities.py
@@ -2,11 +2,10 @@ from __future__ import absolute_import
 
 from typing import Union, Any
 
-import six
 import re
 from collections import namedtuple
 
-SCALAR_TYPES = tuple(list(six.string_types) + [int, float, bool])
+SCALAR_TYPES = (str, int, float, bool)
 
 ECMA_TO_PYTHON_FLAGS = {
     "i": re.I,
@@ -16,14 +15,6 @@ ECMA_TO_PYTHON_FLAGS = {
 PYTHON_TO_ECMA_FLAGS = dict((value, key) for key, value in ECMA_TO_PYTHON_FLAGS.items())
 
 PythonRegex = namedtuple("PythonRegex", ["regex", "flags"])
-
-
-def _normalize_string_type(value: Any) -> Union[str, Any]:
-    if isinstance(value, six.string_types):
-        return str(value)
-    else:
-        return value
-
 
 def _compare_dicts(one: dict, two: dict) -> bool:
     if len(one) != len(two):
@@ -73,9 +64,6 @@ def compare_schemas(one: Any, two: Any) -> bool:
     :rtype: `bool`
 
     """
-    one = _normalize_string_type(one)
-    two = _normalize_string_type(two)
-
     _assert_same_types(one, two)
 
     if isinstance(one, list):

--- a/clearml/backend_api/session/response.py
+++ b/clearml/backend_api/session/response.py
@@ -2,8 +2,6 @@ from typing import Any
 
 import requests
 
-import six
-
 from . import jsonmodels
 from .apimodel import ApiModel
 from .datamodel import NonStrictDataModelMixin
@@ -14,7 +12,7 @@ class FloatOrStringField(jsonmodels.fields.BaseField):
 
     types = (
         float,
-        six.string_types,
+        str,
     )
 
 

--- a/clearml/backend_interface/metrics/reporter.py
+++ b/clearml/backend_interface/metrics/reporter.py
@@ -546,7 +546,7 @@ class Reporter(InterfaceBase, AbstractContextManager, SetupUploadMixin, AsyncMan
                         else:
                             d[k] = to_base_type(v)
             plot = json.dumps(plot, default=default)
-        elif not isinstance(plot, six.string_types):
+        elif not isinstance(plot, str):
             raise ValueError("Plot should be a string or a dict")
 
         ev = PlotEvent(
@@ -686,7 +686,7 @@ class Reporter(InterfaceBase, AbstractContextManager, SetupUploadMixin, AsyncMan
             raise ValueError("Upload configuration is required (use setup_upload())")
         if len([x for x in (path, stream) if x is not None]) != 1:
             raise ValueError("Expected only one of [filename, stream]")
-        if isinstance(stream, six.string_types):
+        if isinstance(stream, str):
             stream = six.StringIO(stream)
 
         kwargs = dict(

--- a/clearml/backend_interface/model.py
+++ b/clearml/backend_interface/model.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 from functools import partial
 from typing import Optional, Callable, Union, Dict, List, Any
 
-import six
 from pathlib2 import Path
 
 from .base import IdObjectBase
@@ -216,7 +215,7 @@ class Model(IdObjectBase, AsyncManagerMixin, _StorageUriMixin):
         if not design:
             return ""
 
-        if isinstance(design, six.string_types):
+        if isinstance(design, str):
             return design
 
         if isinstance(design, dict):

--- a/clearml/backend_interface/task/task.py
+++ b/clearml/backend_interface/task/task.py
@@ -206,8 +206,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
         self._raise_on_validation_errors = raise_on_validation_errors
         self._parameters_allowed_types = tuple(
             set(
-                six.string_types
-                + six.integer_types
+                six.integer_types
                 + (str, float, list, tuple, dict, type(None), Enum)  # noqa
             )
         )
@@ -1564,7 +1563,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
                 return
             if not (
                 isinstance(enumeration, dict)
-                and all(isinstance(k, six.string_types) and isinstance(v, int) for k, v in enumeration.items())
+                and all(isinstance(k, str) and isinstance(v, int) for k, v in enumeration.items())
             ):
                 raise ValueError("Expected label to be a dict[str => int]")
             execution.model_labels = enumeration
@@ -1897,7 +1896,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
             return
 
         if not project_id:
-            assert isinstance(project_name, six.string_types)
+            assert isinstance(project_name, str)
             res = self.send(
                 projects.GetAllRequest(name=exact_match_regex(project_name)),
                 raise_on_errors=False,
@@ -1906,7 +1905,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
                 return False
             project_id = res.response.projects[0].id
 
-        assert isinstance(project_id, six.string_types)
+        assert isinstance(project_id, str)
         self._set_task_property("project", project_id)
         self._edit(project=project_id)
 
@@ -2839,7 +2838,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
         # make sure we have str as values:
         for key in requirements.keys():
             # fix python2 support (str/unicode)
-            if requirements[key] and not isinstance(requirements[key], six.string_types):
+            if requirements[key] and not isinstance(requirements[key], str):
                 requirements[key] = "\n".join(requirements[key])
 
         # protection, Old API might not support it

--- a/clearml/backend_interface/util.py
+++ b/clearml/backend_interface/util.py
@@ -2,7 +2,7 @@ import getpass
 import re
 from _socket import gethostname
 from datetime import datetime, timezone
-from typing import Optional, Any
+from typing import Optional, Any, Tuple, Union
 
 from ..backend_api.services import projects, queues
 from ..debugging.log import get_logger, LoggerRoot
@@ -245,7 +245,12 @@ def mutually_exclusive(
         raise _exception_cls("Only one of (%s) is allowed" % ", ".join(kwargs.keys()))
 
 
-def validate_dict(obj: dict, key_types: type, value_types: type, desc: str = "") -> None:
+def validate_dict(
+    obj: dict,
+    key_types: Union[type, Tuple[type]],
+    value_types: Union[type, Tuple[type]],
+    desc: str = "",
+) -> None:
     if not isinstance(obj, dict):
         raise ValueError("%sexpected a dictionary" % ("%s: " % desc if desc else ""))
     if not all(isinstance(x, key_types) for x in obj.keys()):

--- a/clearml/binding/artifacts.py
+++ b/clearml/binding/artifacts.py
@@ -13,7 +13,6 @@ from time import time
 from typing import Dict, Union, Optional, Sequence, Callable, TYPE_CHECKING, Any
 from zipfile import ZipFile, ZIP_DEFLATED
 
-import six
 import yaml
 from PIL import Image
 from pathlib2 import Path
@@ -427,7 +426,7 @@ class Artifacts:
 
         # try to convert string Path object (it might reference a file/folder)
         # dont not try to serialize long texts.
-        if isinstance(artifact_object, six.string_types) and artifact_object and len(artifact_object) < 2048:
+        if isinstance(artifact_object, str) and artifact_object and len(artifact_object) < 2048:
             # noinspection PyBroadException
             try:
                 artifact_path = Path(artifact_object)
@@ -753,7 +752,7 @@ class Artifacts:
             local_filename = artifact_object
             delete_after_upload = True
         elif (
-            isinstance(artifact_object, six.string_types)
+            isinstance(artifact_object, str)
             and len(artifact_object) < 4096
             and urlparse(artifact_object).scheme in remote_driver_schemes
         ):
@@ -764,7 +763,7 @@ class Artifacts:
             artifact_type_data.content_type = mimetypes.guess_type(artifact_object)[0]
             if preview:
                 artifact_type_data.preview = preview
-        elif isinstance(artifact_object, six.string_types) and artifact_object:
+        elif isinstance(artifact_object, str) and artifact_object:
             # if we got here, we should store it as text file.
             artifact_type = "string"
             artifact_type_data.content_type = "text/plain"

--- a/clearml/binding/frameworks/catboost_bind.py
+++ b/clearml/binding/frameworks/catboost_bind.py
@@ -1,7 +1,6 @@
 import sys
 from typing import Callable, Union, IO, Any
 
-import six
 from pathlib2 import Path
 
 from ..frameworks import WeightsFileHandler, _Empty, _patched_call
@@ -62,7 +61,7 @@ class PatchCatBoostModelIO(PatchBaseModelIO):
         ret = original_fn(obj, f, *args, **kwargs)
         if not PatchCatBoostModelIO._current_task:
             return ret
-        if isinstance(f, six.string_types):
+        if isinstance(f, str):
             filename = f
         else:
             filename = None
@@ -88,9 +87,9 @@ class PatchCatBoostModelIO(PatchBaseModelIO):
         if not PatchCatBoostModelIO._current_task:
             return original_fn(f, *args, **kwargs)
 
-        if isinstance(f, six.string_types):
+        if isinstance(f, str):
             filename = f
-        elif len(args) >= 1 and isinstance(args[0], six.string_types):
+        elif len(args) >= 1 and isinstance(args[0], str):
             filename = args[0]
         else:
             filename = None

--- a/clearml/binding/frameworks/lightgbm_bind.py
+++ b/clearml/binding/frameworks/lightgbm_bind.py
@@ -1,7 +1,6 @@
 import sys
 from typing import Callable, Union, IO, Optional, Any
 
-import six
 from pathlib2 import Path
 
 from ..frameworks import _patched_call, WeightsFileHandler, _Empty
@@ -49,7 +48,7 @@ class PatchLIGHTgbmModelIO(PatchBaseModelIO):
         if not PatchLIGHTgbmModelIO._current_task:
             return ret
 
-        if isinstance(f, six.string_types):
+        if isinstance(f, str):
             filename = f
         elif hasattr(f, "name"):
             filename = f.name
@@ -82,11 +81,11 @@ class PatchLIGHTgbmModelIO(PatchBaseModelIO):
         if not PatchLIGHTgbmModelIO._current_task:
             return original_fn(model_file, *args, **kwargs)
 
-        if isinstance(model_file, six.string_types):
+        if isinstance(model_file, str):
             filename = model_file
         elif hasattr(model_file, "name"):
             filename = model_file.name
-        elif len(args) == 1 and isinstance(args[0], six.string_types):
+        elif len(args) == 1 and isinstance(args[0], str):
             filename = args[0]
         else:
             filename = None

--- a/clearml/binding/frameworks/megengine_bind.py
+++ b/clearml/binding/frameworks/megengine_bind.py
@@ -1,7 +1,6 @@
 import sys
 from typing import Callable, Union, IO, Any
 
-import six
 from pathlib2 import Path
 
 from ..frameworks import _patched_call, WeightsFileHandler, _Empty
@@ -62,7 +61,7 @@ class PatchMegEngineModelIO(PatchBaseModelIO):
 
         # noinspection PyBroadException
         try:
-            if isinstance(f, six.string_types):
+            if isinstance(f, str):
                 filename = f
             elif hasattr(f, "as_posix"):
                 filename = f.as_posix()
@@ -73,7 +72,7 @@ class PatchMegEngineModelIO(PatchBaseModelIO):
                 except Exception:
                     pass
 
-                if not isinstance(f.name, six.string_types):
+                if not isinstance(f.name, str):
                     # Probably a BufferedRandom object that has no meaningful name (still no harm flushing)  # noqa
                     return ret
 
@@ -109,7 +108,7 @@ class PatchMegEngineModelIO(PatchBaseModelIO):
 
         # noinspection PyBroadException
         try:
-            if isinstance(f, six.string_types):
+            if isinstance(f, str):
                 filename = f
             elif hasattr(f, "as_posix"):
                 filename = f.as_posix()
@@ -145,7 +144,7 @@ class PatchMegEngineModelIO(PatchBaseModelIO):
 
         # noinspection PyBroadException
         try:
-            if isinstance(f, six.string_types):
+            if isinstance(f, str):
                 filename = f
             elif hasattr(f, "as_posix"):
                 filename = f.as_posix()

--- a/clearml/binding/frameworks/pytorch_bind.py
+++ b/clearml/binding/frameworks/pytorch_bind.py
@@ -3,7 +3,6 @@ import sys
 import threading
 from typing import Callable, Optional, Any
 
-import six
 from pathlib2 import Path
 
 from ..frameworks import (
@@ -225,7 +224,7 @@ class PatchPyTorchModelIO(PatchBaseModelIO):
 
         # noinspection PyBroadException
         try:
-            if isinstance(f, six.string_types):
+            if isinstance(f, str):
                 filename = f
             elif hasattr(f, "as_posix"):
                 filename = f.as_posix()
@@ -236,7 +235,7 @@ class PatchPyTorchModelIO(PatchBaseModelIO):
                 except Exception:
                     pass
 
-                if not isinstance(f.name, six.string_types):
+                if not isinstance(f.name, str):
                     # Probably a BufferedRandom object that has no meaningful name (still no harm flushing)
                     return ret
 
@@ -271,7 +270,7 @@ class PatchPyTorchModelIO(PatchBaseModelIO):
 
         # noinspection PyBroadException
         try:
-            if isinstance(f, six.string_types):
+            if isinstance(f, str):
                 filename = f
             elif hasattr(f, "as_posix"):
                 filename = f.as_posix()
@@ -314,7 +313,7 @@ class PatchPyTorchModelIO(PatchBaseModelIO):
 
         # noinspection PyBroadException
         try:
-            if isinstance(f, six.string_types):
+            if isinstance(f, str):
                 filename = f
             elif hasattr(f, "as_posix"):
                 filename = f.as_posix()

--- a/clearml/binding/frameworks/tensorflow_bind.py
+++ b/clearml/binding/frameworks/tensorflow_bind.py
@@ -592,7 +592,7 @@ class EventTrainsWriter:
         # update scalar cache
         num, value = self._scalar_report_cache.get((title, series), (0, 0))
         # nan outputs is a string, it's probably a NaN
-        if isinstance(scalar_data, six.string_types):
+        if isinstance(scalar_data, str):
             # noinspection PyBroadException
             try:
                 scalar_data = float(scalar_data)

--- a/clearml/binding/frameworks/xgboost_bind.py
+++ b/clearml/binding/frameworks/xgboost_bind.py
@@ -1,7 +1,6 @@
 import sys
 from typing import Callable, Union, IO, Optional, Dict, List, TYPE_CHECKING, Any
 
-import six
 from pathlib2 import Path
 
 from ..frameworks import _patched_call, WeightsFileHandler, _Empty
@@ -72,7 +71,7 @@ class PatchXGBoostModelIO(PatchBaseModelIO):
         if not PatchXGBoostModelIO._current_task:
             return ret
 
-        if isinstance(f, six.string_types):
+        if isinstance(f, str):
             filename = f
         elif hasattr(f, "name"):
             filename = f.name
@@ -105,11 +104,11 @@ class PatchXGBoostModelIO(PatchBaseModelIO):
         if not PatchXGBoostModelIO._current_task:
             return original_fn(f, *args, **kwargs)
 
-        if isinstance(f, six.string_types):
+        if isinstance(f, str):
             filename = f
         elif hasattr(f, "name"):
             filename = f.name
-        elif len(args) == 1 and isinstance(args[0], six.string_types):
+        elif len(args) == 1 and isinstance(args[0], str):
             filename = args[0]
         else:
             filename = None

--- a/clearml/binding/joblib_bind.py
+++ b/clearml/binding/joblib_bind.py
@@ -4,7 +4,6 @@ from functools import partial
 from io import IOBase
 from typing import Callable, Union, IO, Any
 
-import six
 from pathlib2 import Path
 
 from .import_bind import PostImportHookPatching
@@ -109,15 +108,15 @@ class PatchedJoblib:
         if not PatchedJoblib._current_task:
             return ret
 
-        fname = f if isinstance(f, six.string_types) else None
-        fileobj = ret if isinstance(f, six.string_types) else f
+        fname = f if isinstance(f, str) else None
+        fileobj = ret if isinstance(f, str) else f
 
         if fileobj and hasattr(fileobj, "close"):
 
             def callback(*_: Any) -> None:
                 PatchedJoblib._register_dump(obj, fname or fileobj)
 
-            if isinstance(fname, six.string_types) or hasattr(fileobj, "name"):
+            if isinstance(fname, str) or hasattr(fileobj, "name"):
                 buffer_writer_close_cb(fileobj, callback)
         else:
             PatchedJoblib._register_dump(obj, f)
@@ -130,15 +129,15 @@ class PatchedJoblib:
         if not PatchedJoblib._current_task:
             return ret
 
-        fname = f if isinstance(f, six.string_types) else None
-        fileobj = ret if isinstance(f, six.string_types) else f
+        fname = f if isinstance(f, str) else None
+        fileobj = ret if isinstance(f, str) else f
 
         if fileobj and hasattr(fileobj, "close"):
 
             def callback(*_: Any) -> None:
                 PatchedJoblib._register_dump(obj, fname or fileobj)
 
-            if isinstance(fname, six.string_types) or hasattr(fileobj, "name"):
+            if isinstance(fname, str) or hasattr(fileobj, "name"):
                 buffer_writer_close_cb(fileobj, callback)
         else:
             PatchedJoblib._register_dump(obj, f)

--- a/clearml/model.py
+++ b/clearml/model.py
@@ -1112,13 +1112,13 @@ class BaseModel:
 
     @staticmethod
     def _config_dict_to_text(config: Union[str, dict]) -> str:
-        if not isinstance(config, six.string_types) and not isinstance(config, dict):
+        if not isinstance(config, (str, dict)):
             raise ValueError("Model configuration only supports dictionary or string objects")
         return config_dict_to_text(config)
 
     @staticmethod
     def _text_to_config_dict(text: str) -> dict:
-        if not isinstance(text, six.string_types):
+        if not isinstance(text, str):
             raise ValueError("Model configuration parsing only supports string")
         return text_to_config_dict(text)
 
@@ -2655,7 +2655,7 @@ class OutputModel(BaseModel):
         """
         validate_dict(
             labels,
-            key_types=six.string_types,
+            key_types=str,
             value_types=six.integer_types,
             desc="label enumeration",
         )

--- a/clearml/storage/util.py
+++ b/clearml/storage/util.py
@@ -7,7 +7,6 @@ import sys
 from typing import Optional, Union, Sequence, Dict, Callable, List, Any, Tuple
 from zlib import crc32
 
-import six
 from pathlib2 import Path
 from six.moves.urllib.parse import quote, urlparse, urlunparse
 
@@ -15,7 +14,7 @@ from ..debugging.log import LoggerRoot
 
 
 def get_config_object_matcher(**patterns: Any) -> Callable:
-    unsupported = {k: v for k, v in patterns.items() if not isinstance(v, six.string_types)}
+    unsupported = {k: v for k, v in patterns.items() if not isinstance(v, str)}
     if unsupported:
         raise ValueError(
             "Unsupported object matcher (expecting string): %s"

--- a/clearml/task.py
+++ b/clearml/task.py
@@ -36,7 +36,6 @@ from typing import (
 )
 
 import psutil
-import six
 from pathlib2 import Path
 
 from .backend_config.defs import get_active_config_file, get_config_file
@@ -233,7 +232,7 @@ class Task(_Task):
 
         @classmethod
         def _options(cls):
-            return {var for var, val in vars(cls).items() if isinstance(val, six.string_types)}
+            return {var for var, val in vars(cls).items() if isinstance(val, str)}
 
     def __init__(self, private: Optional[Any] = None, **kwargs: Any) -> None:
         """
@@ -587,7 +586,7 @@ class Task(_Task):
             # Backwards compatibility: if called from Task.current_task and task_type
             # was not specified, keep legacy default value of TaskTypes.training
             task_type = cls.TaskTypes.training
-        elif isinstance(task_type, six.string_types):
+        elif isinstance(task_type, str):
             if task_type not in Task.TaskTypes.__members__:
                 raise ValueError(
                     "Task type '{}' not supported, options are: {}".format(task_type, Task.TaskTypes.__members__.keys())
@@ -1791,15 +1790,15 @@ class Task(_Task):
         :return: The new cloned Task (experiment).
         :rtype: Task
         """
-        assert isinstance(source_task, (six.string_types, Task))
+        assert isinstance(source_task, (str, Task))
         if not Session.check_min_api_version("2.4"):
             raise ValueError(
                 "ClearML-server does not support DevOps features, upgrade clearml-server to 0.12.0 or above"
             )
 
-        task_id = source_task if isinstance(source_task, six.string_types) else source_task.id
+        task_id = source_task if isinstance(source_task, str) else source_task.id
         if not parent:
-            if isinstance(source_task, six.string_types):
+            if isinstance(source_task, str):
                 source_task = cls.get_task(task_id=source_task)
             parent = source_task.id if not source_task.parent else source_task.parent
         elif isinstance(parent, Task):
@@ -1864,7 +1863,7 @@ class Task(_Task):
               - ``execution.queue`` - The ID of the queue where the Task is enqueued. ``null`` indicates not enqueued.
 
         """
-        assert isinstance(task, (six.string_types, Task))
+        assert isinstance(task, (str, Task))
         if not Session.check_min_api_version("2.4"):
             raise ValueError(
                 "ClearML-server does not support DevOps features, upgrade clearml-server to 0.12.0 or above"
@@ -1873,7 +1872,7 @@ class Task(_Task):
         # make sure we have wither name ot id
         mutually_exclusive(queue_name=queue_name, queue_id=queue_id)
 
-        task_id = task if isinstance(task, six.string_types) else task.id
+        task_id = task if isinstance(task, str) else task.id
         session = cls._get_default_session()
         if not queue_id:
             queue_id = get_queue_id(session, queue_name)
@@ -1964,13 +1963,13 @@ class Task(_Task):
         - ``updated`` - The number of Tasks updated (an integer or ``null``).
 
         """
-        assert isinstance(task, (six.string_types, Task))
+        assert isinstance(task, (str, Task))
         if not Session.check_min_api_version("2.4"):
             raise ValueError(
                 "ClearML-server does not support DevOps features, upgrade clearml-server to 0.12.0 or above"
             )
 
-        task_id = task if isinstance(task, six.string_types) else task.id
+        task_id = task if isinstance(task, str) else task.id
         session = cls._get_default_session()
         req = tasks.DequeueRequest(task=task_id)
         res = cls._send(session=session, req=req)
@@ -2009,7 +2008,7 @@ class Task(_Task):
         :param tags: A list of tags which describe the Task to add.
         """
 
-        if isinstance(tags, six.string_types):
+        if isinstance(tags, str):
             tags = tags.split(" ")
 
         self.data.tags = list(
@@ -2219,7 +2218,7 @@ class Task(_Task):
         )
         pathlib_Path = None  # noqa
         cast_Path = Path
-        if not isinstance(configuration, (dict, list, Path, six.string_types)):
+        if not isinstance(configuration, (dict, list, Path, str)):
             try:
                 from pathlib import Path as pathlib_Path  # noqa
             except ImportError:
@@ -3868,7 +3867,7 @@ class Task(_Task):
         if not target_task:
             project_name = task_data.get("project_name") or Task._get_project_name(task_data.get("project", ""))
             target_task = Task.create(project_name=project_name, task_name=task_data.get("name", None))
-        elif isinstance(target_task, six.string_types):
+        elif isinstance(target_task, str):
             target_task: Optional[Task] = Task.get_task(task_id=target_task)
         elif not isinstance(target_task, Task):
             raise ValueError(
@@ -5227,7 +5226,7 @@ class Task(_Task):
         **kwargs: Any,
     ) -> List["Task"]:
         if task_ids:
-            if isinstance(task_ids, six.string_types):
+            if isinstance(task_ids, str):
                 task_ids = [task_ids]
             return [
                 cls(
@@ -5262,7 +5261,7 @@ class Task(_Task):
         res = None
         if not task_ids:
             task_ids = None
-        elif isinstance(task_ids, six.string_types):
+        elif isinstance(task_ids, str):
             task_ids = [task_ids]
 
         if project_name and isinstance(project_name, str):

--- a/clearml/utilities/config.py
+++ b/clearml/utilities/config.py
@@ -12,7 +12,7 @@ from ..storage.util import parse_size
 
 
 def parse_human_size(value: Any) -> Any:
-    if isinstance(value, six.string_types):
+    if isinstance(value, str):
         return parse_size(value)
     return value
 
@@ -25,7 +25,7 @@ def get_percentage(config: dict, key: str, required: bool = True, default: float
         if value is None:
             return
     try:
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             value = value.strip()
             if value.endswith("%"):
                 # "50%" => 0.5
@@ -55,7 +55,7 @@ def get_human_size_default(config: dict, key: str, default: Any = None) -> Any:
 
 def config_dict_to_text(config: Union[str, dict, list]) -> str:
     # if already string return as is
-    if isinstance(config, six.string_types):
+    if isinstance(config, str):
         return config
     if not isinstance(config, (dict, list)):
         raise ValueError("Configuration only supports dictionary/list objects")
@@ -95,8 +95,8 @@ def config_dict_to_text(config: Union[str, dict, list]) -> str:
     return text
 
 
-def text_to_config_dict(text: six.string_types) -> dict:
-    if not isinstance(text, six.string_types):
+def text_to_config_dict(text: str) -> dict:
+    if not isinstance(text, str):
         raise ValueError("Configuration parsing only supports string")
     # noinspection PyBroadException
     try:
@@ -116,7 +116,7 @@ def verify_basic_value(value: Any) -> bool:
     # return True if value of of basic type (json serializable)
     if not isinstance(
         value,
-        six.string_types + six.integer_types + (str, float, list, tuple, dict, type(None)),
+        six.integer_types + (str, float, list, tuple, dict, type(None)),
     ):
         return False
     try:

--- a/clearml/utilities/deferred.py
+++ b/clearml/utilities/deferred.py
@@ -3,7 +3,6 @@ from functools import wraps
 from typing import Callable, List, Type, Union, Any
 
 import attr
-import six
 
 
 class DeferredExecutionPool:
@@ -90,7 +89,7 @@ class DeferredExecution:
     ) -> Any:
         if callable(condition_or_attr_name):
             return condition_or_attr_name(instance)
-        elif isinstance(condition_or_attr_name, six.string_types):
+        elif isinstance(condition_or_attr_name, str):
             return getattr(instance, condition_or_attr_name)
         return condition_or_attr_name
 

--- a/clearml/utilities/lowlevel/file_access.py
+++ b/clearml/utilities/lowlevel/file_access.py
@@ -3,8 +3,6 @@ import sys
 from functools import partial
 from typing import Optional, Callable, Any
 
-import six
-
 
 def __buffer_writer_close_patch(self) -> None:
     self._trains_org_close()
@@ -39,7 +37,7 @@ def get_filename_from_file_object(
     :param analyze_file_handle: If True, try to retrieve filename from file handler object (default: False)
     :return: string full path of file location or None if filename cannot be extract
     """
-    if isinstance(file_object, six.string_types):
+    if isinstance(file_object, str):
         # noinspection PyBroadException
         try:
             return os.path.abspath(file_object) if file_object else file_object

--- a/clearml/utilities/proxy_object.py
+++ b/clearml/utilities/proxy_object.py
@@ -135,7 +135,7 @@ def verify_basic_type(
             float,
             int,
             bool,
-            six.string_types,
+            str,
         )
         if not basic_types
         else tuple(b for b in basic_types if b not in (list, tuple, dict))
@@ -221,8 +221,6 @@ def get_type_from_basic_type_str(type_str: str) -> type:
 
 
 def get_basic_type(value: Any) -> str:
-    basic_types = (float, int, bool, six.string_types, list, tuple, dict)
-
     if isinstance(value, (list, tuple)) and value:
         tv = type(value)
         t = type(value[0])
@@ -235,7 +233,7 @@ def get_basic_type(value: Any) -> str:
 
     # it might be an empty list/dict/tuple
     t = type(value)
-    if isinstance(value, basic_types):
+    if isinstance(value, (float, int, bool, str, list, tuple, dict)):
         return str(getattr(t, "__name__", t))
 
     # we are storing it, even though we will not be able to restore it
@@ -244,17 +242,12 @@ def get_basic_type(value: Any) -> str:
 
 def flatten_dictionary(a_dict: dict, prefix: str = "", sep: str = "/") -> dict:
     flat_dict = {}
-    basic_types = (
-        float,
-        int,
-        bool,
-        six.string_types,
-    )
+
     for k, v in a_dict.items():
         k = str(k)
-        if isinstance(v, (float, int, bool, six.string_types)):
+        if isinstance(v, (float, int, bool, str)):
             flat_dict[prefix + k] = v
-        elif isinstance(v, (list, tuple)) and all([isinstance(i, basic_types) for i in v]):
+        elif isinstance(v, (list, tuple)) and all([isinstance(i,  (float, int, bool, str)) for i in v]):
             flat_dict[prefix + k] = v
         elif isinstance(v, dict):
             nested_flat_dict = flatten_dictionary(v, prefix=prefix + k + sep, sep=sep)
@@ -270,18 +263,12 @@ def flatten_dictionary(a_dict: dict, prefix: str = "", sep: str = "/") -> dict:
 
 
 def nested_from_flat_dictionary(a_dict: dict, flat_dict: dict, prefix: str = "", sep: str = "/") -> dict:
-    basic_types = (
-        float,
-        int,
-        bool,
-        six.string_types,
-    )
     org_dict = copy(a_dict)
     for k, v in org_dict.items():
         k = str(k)
-        if isinstance(v, (float, int, bool, six.string_types)):
+        if isinstance(v, (float, int, bool, str)):
             a_dict[k] = flat_dict.get(prefix + k, v)
-        elif isinstance(v, (list, tuple)) and all([isinstance(i, basic_types) for i in v]):
+        elif isinstance(v, (list, tuple)) and all([isinstance(i,  (float, int, bool, str)) for i in v]):
             a_dict[k] = flat_dict.get(prefix + k, v)
         elif isinstance(v, dict):
             a_dict[k] = nested_from_flat_dictionary(v, flat_dict, prefix=prefix + k + sep, sep=sep) or v


### PR DESCRIPTION
## Related Issue \ discussion
See [the corresponding issue #1541](https://github.com/clearml/clearml/issues/1541).

## Patch Description
This replaces usage of `six.string_types` by the appropriate Python 3 equivalent (i.e. `str`). 
There was also a type hint on `validate_dict` at `clearml/backend_interface/util.py` which was inappropriately hinted as `type` whereas it should be `Union[type, Tuple[type]]` strictly speaking (it's the second argument to `isinstance`). That function could be simpler but the simplification of this was left out-of-scope.