### PR TITLE
gh-1543: Remove `six.PY2` and `six.PY3` usage

### DIFF
--- a/clearml/backend_api/utils.py
+++ b/clearml/backend_api/utils.py
@@ -8,16 +8,11 @@ from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 from urllib3 import PoolManager
 import urllib3
-import six
 
 from .session.defs import ENV_HOST_VERIFY_CERT
 from ..backend_config.converters import strtobool
 
-if six.PY3:
-    from functools import lru_cache
-elif six.PY2:
-    # python 2 support
-    from backports.functools_lru_cache import lru_cache  # noqa
+from functools import lru_cache
 
 __disable_certificate_verification_warning = 0
 
@@ -154,13 +149,6 @@ def get_http_session_with_retry(
     )
 
     session = SessionWithTimeout()
-
-    # HACK: with python 2.7 there is a potential race condition that can cause
-    # a deadlock when importing "netrc", inside the get_netrc_auth() function
-    # setting 'session.trust_env' to False will make sure the `get_netrc_auth` is not called
-    # see details: https://github.com/psf/requests/issues/2925
-    if six.PY2:
-        session.trust_env = False
 
     if backoff_max is not None:
         if "BACKOFF_MAX" in vars(Retry):

--- a/clearml/backend_interface/metrics/reporter.py
+++ b/clearml/backend_interface/metrics/reporter.py
@@ -495,17 +495,15 @@ class Reporter(InterfaceBase, AbstractContextManager, SetupUploadMixin, AsyncMan
         :param nan_as_null: If True, Convert NaN to None (null), otherwise use 'nan'
         :type nan_as_null: bool
         """
-        inf_value = math.inf if six.PY3 else float("inf")
-
         def to_base_type(
             o: Any,
         ) -> Union[None, str, float, int, datetime.date, datetime.datetime]:
             if isinstance(o, float):
                 if o != o:
                     return None if nan_as_null else "nan"
-                elif o == inf_value:
+                elif o == math.inf:
                     return "inf"
-                elif o == -inf_value:
+                elif o == -math.inf:
                     return "-inf"
                 return round(o, ndigits=round_digits) if round_digits is not None else o
             elif isinstance(o, (datetime.date, datetime.datetime)):

--- a/clearml/backend_interface/task/args.py
+++ b/clearml/backend_interface/task/args.py
@@ -5,7 +5,6 @@ import yaml
 from enum import Enum
 from inspect import isfunction
 
-from six import PY2
 from argparse import (
     _StoreAction,  # noqa
     ArgumentError,  # noqa
@@ -513,9 +512,6 @@ class _Arguments:
                         ):
                             current_action.default = v
                         current_action.required = False
-                        # python2 doesn't support defaults for positional arguments, unless used with nargs=?
-                        if PY2 and not current_action.nargs:
-                            current_action.nargs = "?"
                     else:
                         # do not add parameters that do not exist in argparser, they might be the dict
                         pass

--- a/clearml/binding/absl_bind.py
+++ b/clearml/binding/absl_bind.py
@@ -1,8 +1,6 @@
 """ absl-py FLAGS binding utility functions """
 from typing import Any
 
-import six
-
 from ..backend_interface.task.args import _Arguments
 from ..config import running_remotely
 
@@ -28,10 +26,7 @@ class PatchAbsl:
         try:
             from absl.flags import _defines
 
-            if six.PY2:
-                cls._original_DEFINE_flag = staticmethod(_defines.DEFINE_flag)
-            else:
-                cls._original_DEFINE_flag = _defines.DEFINE_flag
+            cls._original_DEFINE_flag = _defines.DEFINE_flag
             _defines.DEFINE_flag = cls._patched_define_flag
         except Exception:
             # there is no absl
@@ -40,10 +35,7 @@ class PatchAbsl:
         try:
             from absl.flags._flagvalues import FlagValues
 
-            if six.PY2:
-                cls._original_FLAGS_parse_call = staticmethod(FlagValues.__call__)
-            else:
-                cls._original_FLAGS_parse_call = FlagValues.__call__
+            cls._original_FLAGS_parse_call = FlagValues.__call__
             FlagValues.__call__ = cls._patched_FLAGS_parse_call
         except Exception:
             # there is no absl

--- a/clearml/binding/args.py
+++ b/clearml/binding/args.py
@@ -6,8 +6,6 @@ from argparse import ArgumentParser, Namespace
 from copy import copy
 from typing import Optional, List, Union, Dict, Tuple, Callable, Type, Any
 
-from six import PY2
-
 try:
     from argparse import _SubParsersAction
 except ImportError:
@@ -163,43 +161,6 @@ class PatchArgumentParser:
             # sync back and parse
             if running_remotely():
                 if original_parse_fn:
-                    # if we are running python2 check if we have subparsers,
-                    # if we do we need to patch the args, because there is no default subparser
-                    if PY2:
-                        import itertools
-
-                        def _get_sub_parsers_defaults(subparser: _SubParsersAction, prev: list = []) -> list:
-                            actions_grp = (
-                                [v._actions for v in subparser.choices.values()]
-                                if isinstance(subparser, _SubParsersAction)
-                                else [subparser._actions]
-                            )
-                            _sub_parsers_defaults = (
-                                [[subparser]] if hasattr(subparser, "default") and subparser.default else []
-                            )
-                            for actions in actions_grp:
-                                _sub_parsers_defaults += [
-                                    _get_sub_parsers_defaults(v, prev)
-                                    for v in actions
-                                    if isinstance(v, _SubParsersAction) and hasattr(v, "default") and v.default
-                                ]
-
-                            return list(itertools.chain.from_iterable(_sub_parsers_defaults))
-
-                        sub_parsers_defaults = _get_sub_parsers_defaults(self)
-                        if sub_parsers_defaults:
-                            if args is None:
-                                # args default to the system args
-                                import sys as _sys
-
-                                args = _sys.argv[1:]
-                            else:
-                                args = list(args)
-                            # make sure we append the subparsers
-                            for a in sub_parsers_defaults:
-                                if a.default not in args:
-                                    args.append(a.default)
-
                     parsed_args = original_parse_fn(self, args=args, namespace=namespace)
                     PatchArgumentParser._add_last_parsed_args(self, parsed_args)
                 else:

--- a/clearml/binding/environ_bind.py
+++ b/clearml/binding/environ_bind.py
@@ -4,8 +4,6 @@ from multiprocessing import pool
 from time import sleep
 from typing import Callable, TYPE_CHECKING, Any
 
-import six
-
 if TYPE_CHECKING:
     from .. import Task
 from ..config import TASK_LOG_ENVIRONMENT, running_remotely, config
@@ -123,11 +121,7 @@ class PatchOsFork:
                 )
                 cls._registered_fork_callbacks = True
             except Exception:
-                # python <3.6
-                if six.PY2:
-                    cls._original_fork = staticmethod(os.fork)
-                else:
-                    cls._original_fork = os.fork
+                cls._original_fork = os.fork
                 os.fork = cls._patched_fork
 
         except Exception:

--- a/clearml/binding/frameworks/__init__.py
+++ b/clearml/binding/frameworks/__init__.py
@@ -7,7 +7,6 @@ from random import randint
 from tempfile import mkstemp
 from typing import TYPE_CHECKING, Callable, Dict, Optional, Union, Any
 
-import six
 from pathlib2 import Path
 
 from ...backend_interface.model import Model
@@ -25,7 +24,7 @@ _recursion_guard = {}
 def _patched_call(original_fn: Callable, patched_fn: Callable) -> Callable:
     def _inner_patch(*args: Any, **kwargs: Any) -> Any:
         # noinspection PyProtectedMember,PyUnresolvedReferences
-        ident = threading._get_ident() if six.PY2 else threading.get_ident()
+        ident = threading.get_ident()
         if ident in _recursion_guard:
             return original_fn(*args, **kwargs)
         _recursion_guard[ident] = 1

--- a/clearml/binding/import_bind.py
+++ b/clearml/binding/import_bind.py
@@ -1,16 +1,8 @@
 import sys
+import builtins
 import types
 from collections import defaultdict
 from typing import Callable, Any
-
-import six
-
-if six.PY2:
-    # python2.x
-    import __builtin__ as builtins
-else:
-    # python3.x
-    import builtins
 
 
 class PostImportHookPatching:
@@ -23,14 +15,8 @@ class PostImportHookPatching:
             return
         PostImportHookPatching._patched = True
 
-        if six.PY2:
-            # python2.x
-            builtins.__org_import__ = builtins.__import__
-            builtins.__import__ = PostImportHookPatching.__patched_import2
-        else:
-            # python3.x
-            builtins.__org_import__ = builtins.__import__
-            builtins.__import__ = PostImportHookPatching.__patched_import3
+        builtins.__org_import__ = builtins.__import__
+        builtins.__import__ = PostImportHookPatching.__patched_import3
 
     @staticmethod
     def __patched_import2(

--- a/clearml/binding/matplotlib_bind.py
+++ b/clearml/binding/matplotlib_bind.py
@@ -8,7 +8,7 @@ from typing import Union, Dict, List, Tuple, TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     import matplotlib
-import six
+
 from six import BytesIO
 
 from .import_bind import PostImportHookPatching
@@ -92,16 +92,10 @@ class PatchedMatplotlib:
             import matplotlib.pyplot as plt
             import matplotlib.figure as figure
 
-            if six.PY2:
-                PatchedMatplotlib._patched_original_plot = staticmethod(plt.show)
-                PatchedMatplotlib._patched_original_imshow = staticmethod(plt.imshow)
-                PatchedMatplotlib._patched_original_figure = staticmethod(figure.Figure.show)
-                PatchedMatplotlib._patched_original_savefig = staticmethod(figure.Figure.savefig)
-            else:
-                PatchedMatplotlib._patched_original_plot = plt.show
-                PatchedMatplotlib._patched_original_imshow = plt.imshow
-                PatchedMatplotlib._patched_original_figure = figure.Figure.show
-                PatchedMatplotlib._patched_original_savefig = figure.Figure.savefig
+            PatchedMatplotlib._patched_original_plot = plt.show
+            PatchedMatplotlib._patched_original_imshow = plt.imshow
+            PatchedMatplotlib._patched_original_figure = figure.Figure.show
+            PatchedMatplotlib._patched_original_savefig = figure.Figure.savefig
 
             # noinspection PyBroadException
             try:
@@ -254,20 +248,15 @@ class PatchedMatplotlib:
         # noinspection PyBroadException
         try:
             fname = kw.get("fname") or args[0]
-            from pathlib2 import Path
-
-            if six.PY3:
-                from pathlib import Path as Path3
-            else:
-                Path3 = Path
+            from pathlib import Path
 
             # if we are not storing into a file (str/Path) do not log the matplotlib
-            if not isinstance(fname, (str, Path, Path3)):
+            if not isinstance(fname, (str, Path)):
                 return ret
         except Exception:
             pass
 
-        tid = threading._get_ident() if six.PY2 else threading.get_ident()
+        tid = threading.get_ident()
         if not PatchedMatplotlib._recursion_guard.get(tid):
             PatchedMatplotlib._recursion_guard[tid] = True
             # noinspection PyBroadException
@@ -283,7 +272,7 @@ class PatchedMatplotlib:
     def patched_figure_show(self, *args: Any, **kw: Any) -> Any:
         if not PatchedMatplotlib._current_task:
             return PatchedMatplotlib._patched_original_figure(self, *args, **kw)
-        tid = threading._get_ident() if six.PY2 else threading.get_ident()
+        tid = threading.get_ident()
         if PatchedMatplotlib._recursion_guard.get(tid):
             # we are inside a gaurd do nothing
             return PatchedMatplotlib._patched_original_figure(self, *args, **kw)
@@ -298,7 +287,7 @@ class PatchedMatplotlib:
     def patched_show(*args: Any, **kw: Any) -> Any:
         if not PatchedMatplotlib._current_task:
             return PatchedMatplotlib._patched_original_plot(*args, **kw)
-        tid = threading._get_ident() if six.PY2 else threading.get_ident()
+        tid = threading.get_ident()
         PatchedMatplotlib._recursion_guard[tid] = True
         # noinspection PyBroadException
         try:

--- a/clearml/config/cache.py
+++ b/clearml/config/cache.py
@@ -1,7 +1,6 @@
 import json
 from os.path import expanduser
 
-import six
 from pathlib2 import Path
 
 from . import running_remotely
@@ -21,8 +20,7 @@ class SessionCache:
     def _load_cache(cls) -> dict:
         # noinspection PyBroadException
         try:
-            flag = "rb" if six.PY2 else "rt"
-            with (Path(expanduser(cls.SESSION_CACHE_FOLDER)) / SESSION_CACHE_FILE).open(flag) as fp:
+            with (Path(expanduser(cls.SESSION_CACHE_FOLDER)) / SESSION_CACHE_FILE).open("rt") as fp:
                 return json.load(fp)
         except Exception:
             return {}
@@ -32,8 +30,7 @@ class SessionCache:
         # noinspection PyBroadException
         try:
             Path(expanduser(cls.SESSION_CACHE_FOLDER)).mkdir(parents=True, exist_ok=True)
-            flag = "wb" if six.PY2 else "wt"
-            with (Path(expanduser(cls.SESSION_CACHE_FOLDER)) / SESSION_CACHE_FILE).open(flag) as fp:
+            with (Path(expanduser(cls.SESSION_CACHE_FOLDER)) / SESSION_CACHE_FILE).open("wt") as fp:
                 json.dump(cache, fp)
         except Exception:
             pass

--- a/clearml/logger.py
+++ b/clearml/logger.py
@@ -424,9 +424,9 @@ class Logger:
             reporter_table = table
         else:
             reporter_table = table.fillna(str(np.nan))
-            replace("NaN", np.nan, math.nan if six.PY3 else float("nan"))
-            replace("Inf", np.inf, math.inf if six.PY3 else float("inf"))
-            minus_inf = [-np.inf, -math.inf if six.PY3 else -float("inf")]
+            replace("NaN", np.nan, math.nan)
+            replace("Inf", np.inf, math.inf)
+            minus_inf = [-np.inf, -math.inf]
             try:
                 minus_inf.append(np.NINF)
             except AttributeError:

--- a/clearml/model.py
+++ b/clearml/model.py
@@ -647,9 +647,9 @@ class BaseModel:
             reporter_table = table
         else:
             reporter_table = table.fillna(str(np.nan))
-            replace("NaN", np.nan, math.nan if six.PY3 else float("nan"))
-            replace("Inf", np.inf, math.inf if six.PY3 else float("inf"))
-            minus_inf = [-np.inf, -math.inf if six.PY3 else -float("inf")]
+            replace("NaN", np.nan, math.nan)
+            replace("Inf", np.inf, math.inf)
+            minus_inf = [-np.inf, -math.inf]
             try:
                 minus_inf.append(np.NINF)
             except AttributeError:

--- a/clearml/utilities/async_manager.py
+++ b/clearml/utilities/async_manager.py
@@ -2,8 +2,6 @@ import os
 import time
 from typing import Optional, Callable, Any
 
-import six
-
 from .process.mp import SingletonLock
 
 
@@ -52,12 +50,7 @@ class AsyncManagerMixin:
             if r.ready():
                 continue
             t = time.time()
-            # bugfix for python2.7 threading issues
-            if six.PY2 and not remaining:
-                while not r.ready():
-                    r.wait(timeout=2.0)
-            else:
-                r.wait(timeout=remaining)
+            r.wait(timeout=remaining)
             count += 1
             if max_num_uploads is not None and max_num_uploads - count <= 0:
                 break

--- a/clearml/utilities/process/exit_hooks.py
+++ b/clearml/utilities/process/exit_hooks.py
@@ -5,8 +5,6 @@ import sys
 import types
 from typing import Callable, Union, Any
 
-import six
-
 from ...logger import Logger
 
 
@@ -26,7 +24,7 @@ class ExitHooks:
         self._import_bind_path = os.path.join("clearml", "binding", "import_bind.py")
 
     def update_callback(self, callback: Callable) -> None:
-        if self._exit_callback and not six.PY2:
+        if self._exit_callback:
             # noinspection PyBroadException
             try:
                 atexit.unregister(self._exit_callback)
@@ -120,7 +118,7 @@ class ExitHooks:
 
         try:
             # remove us from import errors
-            if six.PY3 and isinstance(exctype, type) and issubclass(exctype, ImportError):
+            if isinstance(exctype, type) and issubclass(exctype, ImportError):
                 prev = cur = traceback
                 while cur is not None:
                     tb_next = cur.tb_next

--- a/clearml/utilities/version.py
+++ b/clearml/utilities/version.py
@@ -4,13 +4,9 @@ import re
 from copy import deepcopy
 from typing import Callable, Union, List, Optional, Tuple, Any
 
-import six
 from attr import attrs, attrib
 
-if six.PY3:
-    from math import inf
-else:
-    inf = float("inf")
+from math import inf
 
 
 class InvalidVersion(ValueError):


### PR DESCRIPTION
## Related Issue \ discussion
This PR removes the usage of `six.PY2` and `six.PY3` booleans under the assumption that the code always runs Python 3, and therefore `six.PY2` is always `False` and `six.PY3` is always `True`.

## Patch Description
This removes redundant code under the aforementioned assumptions.