### PR TITLE
gh-1545: Replace `typing.Text` by `str`

### DIFF
--- a/clearml/backend_api/session/client/client.py
+++ b/clearml/backend_api/session/client/client.py
@@ -12,7 +12,6 @@ from operator import itemgetter
 from types import ModuleType
 from typing import (
     Dict,
-    Text,
     Tuple,
     Type,
     Sequence,
@@ -36,12 +35,12 @@ from ....backend_config.defs import LOCAL_CONFIG_FILE_OVERRIDE_VAR
 SERVICE_TO_ENTITY_CLASS_NAMES = {"storage": "StorageItem"}
 
 
-def entity_class_name(service: ModuleType) -> Text:
+def entity_class_name(service: ModuleType) -> str:
     service_name = api_entity_name(service)
     return SERVICE_TO_ENTITY_CLASS_NAMES.get(service_name.lower(), service_name)
 
 
-def api_entity_name(service: ModuleType) -> Text:
+def api_entity_name(service: ModuleType) -> str:
     return module_name(service).rstrip("s")
 
 
@@ -68,7 +67,7 @@ class APIError(Exception):
         self.meta: ResponseMeta = response.meta
         self.code: int = response.meta.result_code
         self.subcode: int = response.meta.result_subcode
-        self.message: Text = response.meta.result_msg
+        self.message: str = response.meta.result_msg
         self.codes: Tuple[int, int] = (self.code, self.subcode)
 
     def get_traceback(self) -> Optional[List[str]]:
@@ -105,14 +104,14 @@ class StrictSession(Session):
 
     def __init__(
         self,
-        config_file: Union[Path, Text] = None,
+        config_file: Union[Path, str] = None,
         initialize_logging: bool = False,
         *args: Any,
         **kwargs: Any,
     ) -> None:
         """
         :param config_file: configuration file to use, else use the default
-        :type config_file: Path | Text
+        :type config_file: Path | str
         """
 
         def init() -> None:
@@ -147,17 +146,17 @@ class Response:
     Exposes "meta" of the original result.
     """
 
-    def __init__(self, result: CallResult, dest: Text = None) -> None:
+    def __init__(self, result: CallResult, dest: str = None) -> None:
         """
         :param result: result of endpoint call
         :type result: CallResult
         :param dest: if all of a response's data is contained in one field, use that field
-        :type dest: Text
+        :type dest: str
         """
         self.response = None
         self._result = result
         response = getattr(result, "response", result)
-        if getattr(response, "_service") == "events" and getattr(response, "_action") in (
+        if getattr(response, "_service", None) == "events" and getattr(response, "_action", None) in (
             "scalar_metrics_iter_histogram",
             "multi_task_scalar_metrics_iter_histogram",
             "vector_metrics_iter_histogram",
@@ -172,7 +171,7 @@ class Response:
             response = getattr(response, dest)
         self.response = response
 
-    def __getattr__(self, attr: Text) -> Any:
+    def __getattr__(self, attr: str) -> Any:
         if self.response is None:
             return None
         return getattr(self.response, attr)
@@ -199,7 +198,7 @@ class TableResponse(Response):
         self,
         service: "Service",
         entity: Any,
-        fields: Sequence[Text] = None,
+        fields: Sequence[str] = None,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -214,18 +213,18 @@ class TableResponse(Response):
         self.fields = fields or ("id", "name")
         self.response = [entity(service, item) for item in self]
 
-    def __repr__(self, fields: Sequence[Text] = None) -> Text:
+    def __repr__(self, fields: Sequence[str] = None) -> str:
         return self._format_table(fields=fields)
 
     __str__ = __repr__
 
-    def _format_table(self, fields: Sequence[Text] = None) -> Text:
+    def _format_table(self, fields: Sequence[str] = None) -> str:
         """
         Display <fields> attributes of each element in a table
         :param fields:
         """
 
-        def getter(obj: Any, attr: Text) -> Text:
+        def getter(obj: Any, attr: str) -> str:
             result = reduce(
                 lambda x, name: x if x is None else getattr(x, name, None),
                 attr.split("."),
@@ -236,7 +235,7 @@ class TableResponse(Response):
         fields = fields or self.fields
         return "\n".join(str(dict((attr, getter(item, attr)) for attr in fields)) for item in self)
 
-    def display(self, fields: Sequence[Text] = None) -> None:
+    def display(self, fields: Sequence[str] = None) -> None:
         print(self._format_table(fields=fields))
 
     def where(self, predicate: Callable[[Any], bool] = None, **kwargs: Any) -> "TableResponse":
@@ -289,7 +288,7 @@ class Entity:
 
     @property
     @abc.abstractmethod
-    def entity_name(self) -> Text:
+    def entity_name(self) -> str:
         """
         Singular name of entity
         """
@@ -315,10 +314,10 @@ class Entity:
         result = self._service.session.send(self.get_by_id_request(self.data.id))
         self.data = getattr(result.response, self.entity_name)
 
-    def _get_default_kwargs(self) -> Dict[Text, Any]:
+    def _get_default_kwargs(self) -> Dict[str, Any]:
         return {self.entity_name: self.data.id}
 
-    def __getattr__(self, attr: Text) -> Any:
+    def __getattr__(self, attr: str) -> Any:
         """
         Inject the entity's ID to the method call.
         All missing properties are assumed to be functions.
@@ -351,7 +350,7 @@ class Entity:
             base = dir_()
         return list(set(base).union(dir(self._service), dir(self.data)))
 
-    def __repr__(self) -> Text:
+    def __repr__(self) -> str:
         """
         Display entity type, ID, and - if available - name.
         """
@@ -427,7 +426,7 @@ def make_action(service: "Service", request_cls: Type["APIRequest"]) -> Callable
             )
 
     else:
-        assert False
+        raise
 
     get.__name__ = get.__qualname__ = action
 
@@ -484,7 +483,7 @@ def make_service_class(module: types.ModuleType) -> Type[Service]:
     return type(str(module_name(module)), (Service,), properties)
 
 
-def module_name(module: Any) -> Text:
+def module_name(module: Any) -> str:
     try:
         module = module.__name__
     except AttributeError:
@@ -523,7 +522,7 @@ class APIClient:
     def __init__(
         self,
         session: Session = None,
-        api_version: Text = None,
+        api_version: str = None,
         **kwargs: Any,
     ) -> None:
         self.session = session or StrictSession()

--- a/clearml/backend_config/config.py
+++ b/clearml/backend_config/config.py
@@ -36,26 +36,20 @@ from .log import initialize as initialize_log, logger
 from .utils import get_options
 from ..utilities.pyhocon import ConfigTree, ConfigFactory
 
-try:
-    from typing import Text
-except ImportError:
-    # windows conda-less hack
-    Text = object
-
 log = logger(__file__)
 
 
 class ConfigEntry(Entry):
     logger = None
 
-    def __init__(self, config: "Config", *keys: Text, **kwargs: Any) -> None:
+    def __init__(self, config: "Config", *keys: str, **kwargs: Any) -> None:
         super(ConfigEntry, self).__init__(*keys, **kwargs)
         self.config = config
 
-    def _get(self, key: Text) -> Any:
+    def _get(self, key: str) -> Any:
         return self.config.get(key, NotSet)
 
-    def error(self, message: Text) -> None:
+    def error(self, message: str) -> None:
         log.error(message.capitalize())
 
 
@@ -106,10 +100,10 @@ class Config:
         self._roots = value
 
     @property
-    def env(self) -> Text:
+    def env(self) -> str:
         return self._env
 
-    def logger(self, path: Text = None) -> logging.Logger:
+    def logger(self, path: str = None) -> logging.Logger:
         return logger(path)
 
     def load_relative_to(self, *module_paths: Any) -> None:
@@ -247,10 +241,10 @@ class Config:
         except Exception:
             pass
 
-    def __getitem__(self, key: Text) -> Any:
+    def __getitem__(self, key: str) -> Any:
         return self._config[key]
 
-    def get(self, key: Text, default: Any = _MISSING) -> Any:
+    def get(self, key: str, default: Any = _MISSING) -> Any:
         value = self._config.get(key, default)
         if value is self._MISSING:
             raise KeyError("Unable to find value for key '{}' and default value was not provided.".format(key))
@@ -313,7 +307,7 @@ class Config:
         return conf
 
     @staticmethod
-    def _read_single_file(file_path: Text, verbose: bool = True) -> ConfigTree:
+    def _read_single_file(file_path: str, verbose: bool = True) -> ConfigTree:
         if not file_path or not Path(file_path).is_file():
             return ConfigTree()
 

--- a/clearml/backend_config/converters.py
+++ b/clearml/backend_config/converters.py
@@ -1,16 +1,10 @@
 import base64
 from typing import Union, Optional, Any, TypeVar, Callable, Tuple
 
-try:
-    from typing import Text
-except ImportError:
-    # windows conda-less hack
-    Text = object
-
 ConverterType = TypeVar("ConverterType", bound=Callable[[Any], Any])
 
 
-def strtobool(val: Text) -> int:
+def strtobool(val: str) -> int:
     """Convert a string representation of truth to true (1) or false (0).
 
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
@@ -26,22 +20,22 @@ def strtobool(val: Text) -> int:
         raise ValueError("invalid truth value %r" % (val,))
 
 
-def base64_to_text(value: Any) -> Text:
+def base64_to_text(value: Any) -> str:
     return base64.b64decode(value).decode("utf-8")
 
 
-def text_to_bool(value: Text) -> bool:
+def text_to_bool(value: str) -> bool:
     return bool(strtobool(value))
 
 
-def safe_text_to_bool(value: Text) -> bool:
+def safe_text_to_bool(value: str) -> bool:
     try:
         return bool(strtobool(value))
     except ValueError:
         return bool(value)
 
 
-def any_to_bool(value: Optional[Union[int, float, Text]]) -> bool:
+def any_to_bool(value: Optional[Union[int, float, str]]) -> bool:
     if isinstance(value, str):
         return text_to_bool(value)
     return bool(value)

--- a/clearml/backend_config/entry.py
+++ b/clearml/backend_config/entry.py
@@ -5,12 +5,6 @@ import six
 
 from .converters import any_to_bool
 
-try:
-    from typing import Text
-except ImportError:
-    # windows conda-less hack
-    Text = object
-
 NotSet = object()
 
 Converter = Callable[[Any], Any]
@@ -29,7 +23,7 @@ class Entry:
             str: lambda s: str(s).strip(),
         }
 
-    def __init__(self, key: Text, *more_keys: Text, **kwargs: Any) -> None:
+    def __init__(self, key: str, *more_keys: str, **kwargs: Any) -> None:
         """
         :param key: Entry's key (at least one).
         :param more_keys: More alternate keys for this entry.
@@ -51,7 +45,7 @@ class Entry:
         return str(self.key)
 
     @property
-    def key(self) -> Text:
+    def key(self) -> str:
         return self.keys[0]
 
     def convert(self, value: Any, converter: Converter = None) -> Optional[Any]:
@@ -60,7 +54,7 @@ class Entry:
             converter = self.default_conversions().get(self.type, self.type)
         return converter(value)
 
-    def get_pair(self, default: Any = NotSet, converter: Converter = None) -> Optional[Tuple[Text, Any]]:
+    def get_pair(self, default: Any = NotSet, converter: Converter = None) -> Optional[Tuple[str, Any]]:
         for key in self.keys:
             value = self._get(key)
             if value is NotSet:
@@ -83,15 +77,15 @@ class Entry:
         for k in self.keys:
             self._set(k, str(value))
 
-    def _set(self, key: Text, value: Text) -> None:
+    def _set(self, key: str, value: str) -> None:
         pass
 
     @abc.abstractmethod
-    def _get(self, key: Text) -> Any:
+    def _get(self, key: str) -> Any:
         pass
 
     @abc.abstractmethod
-    def error(self, message: Text) -> None:
+    def error(self, message: str) -> None:
         pass
 
     def exists(self) -> bool:

--- a/clearml/utilities/resource_monitor.py
+++ b/clearml/utilities/resource_monitor.py
@@ -5,7 +5,7 @@ import sys
 import warnings
 from math import ceil, log10
 from time import time
-from typing import Text, Dict, List, Any
+from typing import Dict, List, Any
 
 import psutil
 from pathlib2 import Path
@@ -364,7 +364,7 @@ class ResourceMonitor(BackgroundMonitor):
             bytes_to_megabytes(self._get_process_used_memory() if self._process_info else virtual_memory.used) / 1024
         )
         stats["memory_free_gb"] = bytes_to_megabytes(virtual_memory.available) / 1024
-        disk_use_percentage = psutil.disk_usage(Text(Path.home())).percent
+        disk_use_percentage = psutil.disk_usage(str(Path.home())).percent
         stats["disk_free_percent"] = 100.0 - disk_use_percentage
         with warnings.catch_warnings():
             if logging.root.level > logging.DEBUG:  # If the logging level is bigger than debug, ignore


### PR DESCRIPTION
## Related Issue \ discussion
See the corresponding issue #1545.

## Patch Description
This PR mostly replaces `typing.Text` by `str`. I say "mostly" because it does two other things:
- An instance of `assert False` was found, it was replaced by `raise`. The `assert` keyword is supposed to be used in tests whereas `raise` is for control flow of exceptions, so the latter is better.
- Some usage of `getattr(value, "key")` had no fallback, and `getattr(value, "key", None)` was considered a better implementation by the ClearML team, so it was done.