### PR TITLE
fix: handle NVIDIA_VISIBLE_DEVICES="void" in GPU monitoring (#1508)

### DIFF
--- a/clearml/utilities/resource_monitor.py
+++ b/clearml/utilities/resource_monitor.py
@@ -107,7 +107,7 @@ class ResourceMonitor(BackgroundMonitor):
             # noinspection PyBroadException
             try:
                 active_gpus = os.environ.get("NVIDIA_VISIBLE_DEVICES", "") or os.environ.get("CUDA_VISIBLE_DEVICES", "")
-                if active_gpus and active_gpus != "all":
+                if active_gpus and active_gpus not in ("all", "void"):
                     if os.path.isdir(active_gpus):
                         try:
                             self._active_gpus = os.listdir(active_gpus)
@@ -337,7 +337,7 @@ class ResourceMonitor(BackgroundMonitor):
                 if not self._skip_nonactive_gpu(gpu):
                     skips_all = False
                     break
-            if skips_all and active_gpus != "none":
+            if skips_all and active_gpus not in ("none", "void"):
                 self._active_gpus = None
         except Exception as e:
             logging.getLogger("clearml.resource_monitor").warning(


### PR DESCRIPTION
## Summary

- Treat `NVIDIA_VISIBLE_DEVICES="void"` as "no GPU filtering needed" instead of trying to parse it as a GPU ID list
- Fix applied in both initial GPU detection (line 110) and `_fix_active_gpus()` fallback (line 340)

## Root cause

The latest NVIDIA gpu-operator for Kubernetes sets `NVIDIA_VISIBLE_DEVICES=void` (see [NVIDIA/gpu-operator#1994](https://github.com/NVIDIA/gpu-operator/issues/1994)). ClearML's resource monitor checked for `"all"` and `"none"` as special values, but not `"void"`. This caused `"void"` to be parsed as a comma-separated GPU ID list `["void"]`, which then failed to match any actual GPU index, silently breaking GPU utilization reporting.

## Changes

| Location | Change |
|---|---|
| `resource_monitor.py:110` | `!= "all"` → `not in ("all", "void")` |
| `resource_monitor.py:340` | `!= "none"` → `not in ("none", "void")` |

Fixes #1508

## Test plan

- [ ] Set `NVIDIA_VISIBLE_DEVICES=void` and verify GPU monitoring works
- [ ] Verify existing behavior unchanged for `"all"`, `"none"`, and comma-separated GPU IDs