### PR TITLE
Fix import clearml hanging when server unreachable (issue #1517)

### DIFF
--- a/clearml/backend_interface/datasets/__init__.py
+++ b/clearml/backend_interface/datasets/__init__.py
@@ -1,10 +1,13 @@
 """Backend dataset helpers for HyperDatasets."""
 
-from .hyper_dataset import HyperDatasetManagementBackend, _SaveFramesRequestNoValidate
+from .hyper_dataset import (
+    HyperDatasetManagementBackend,
+    _get_save_frames_request_no_validate,
+)
 from .hyper_dataset_data_view import DataViewManagementBackend
 
 __all__ = [
     "HyperDatasetManagementBackend",
-    "_SaveFramesRequestNoValidate",
+    "_get_save_frames_request_no_validate",
     "DataViewManagementBackend",
 ]

--- a/clearml/backend_interface/datasets/hyper_dataset.py
+++ b/clearml/backend_interface/datasets/hyper_dataset.py
@@ -7,13 +7,35 @@ from ..util import exact_match_regex
 from ..session import SendError
 from ...task import Task
 
-# handle import in offline mode
-_SaveFramesRequest = datasets.SaveFramesRequest if getattr(datasets, "SaveFramesRequest", None) else object
+# Lazy initialization to avoid Session creation during import (#1517)
+_SaveFramesRequestNoValidate = None
 
 
-class _SaveFramesRequestNoValidate(_SaveFramesRequest):
-    def validate(self, schema=None):
-        pass
+def _get_save_frames_request_no_validate():
+    """
+    Lazily create _SaveFramesRequestNoValidate class to avoid
+    import-time Session creation.
+
+    Issue #1517: Accessing datasets.SaveFramesRequest at module level
+    triggers __getattr__ in api_proxy.py, which creates a Session and
+    tries to connect to the server. This causes import to hang when
+    the server is unreachable.
+    """
+    global _SaveFramesRequestNoValidate
+    if _SaveFramesRequestNoValidate is None:
+        base_class = (
+            datasets.SaveFramesRequest
+            if getattr(datasets, "SaveFramesRequest", None)
+            else object
+        )
+
+        class _SaveFramesRequestNoValidateImpl(base_class):
+            def validate(self, schema=None):
+                pass
+
+        _SaveFramesRequestNoValidate = _SaveFramesRequestNoValidateImpl
+
+    return _SaveFramesRequestNoValidate
 
 
 class HyperDatasetManagementBackend(IdObjectBase):
@@ -134,7 +156,7 @@ class HyperDatasetManagementBackend(IdObjectBase):
                 frames.append(de.to_api_object())
             else:
                 frames.append(de)
-        req = _SaveFramesRequestNoValidate(version=dataset_id, frames=frames)
+        req = _get_save_frames_request_no_validate()(version=dataset_id, frames=frames)
         res = cls._send(cls._get_default_session(), req)
         return res.response
 

--- a/clearml/hyperdatasets/core.py
+++ b/clearml/hyperdatasets/core.py
@@ -6,7 +6,10 @@ import psutil
 from requests.compat import json as requests_json
 
 from clearml.backend_api import Session
-from clearml.backend_interface.datasets.hyper_dataset import HyperDatasetManagementBackend, _SaveFramesRequestNoValidate
+from clearml.backend_interface.datasets.hyper_dataset import (
+    HyperDatasetManagementBackend,
+    _get_save_frames_request_no_validate,
+)
 from clearml.backend_interface.util import get_or_create_project
 from clearml.storage.helper import StorageHelperDiskSpaceFileSizeStrategy
 from clearml.storage.manager import StorageManagerDiskSpaceFileSizeStrategy
@@ -166,10 +169,12 @@ class HyperDataset(HyperDatasetManagement):
         current_batch = []
         current_batch_size = 0
         errors = {}
+        request_class = _get_save_frames_request_no_validate()
+        empty_request = request_class(
+            version=self._version_id, frames=[]
+        )
         request_fixed_size = len(
-            requests_json.dumps(_SaveFramesRequestNoValidate(version=self._version_id, frames=[]).to_dict()).encode(
-                "utf-8"
-            )
+            requests_json.dumps(empty_request.to_dict()).encode("utf-8")
         )
         max_request_size_bytes = (max_request_size_mb * 1024 * 1024) - request_fixed_size
         for data_entry in data_entries:


### PR DESCRIPTION
## Summary
Fixes #1517 - `import clearml` no longer hangs when the ClearML server is unreachable.

## Problem
Importing clearml caused the process to hang indefinitely when the server was not reachable, even though no ClearML functionality was being used. This broke:
- Conditional ClearML usage (can't parse args to decide whether to use ClearML)
- Optional ClearML integrations (can't try/except around Task.init)
- CI/CD environments without server access

## Root Cause
Module-level code in `clearml/backend_interface/datasets/hyper_dataset.py` accessed `datasets.SaveFramesRequest`, which triggered `__getattr__` in `api_proxy.py`. This created a Session and immediately attempted to connect to the server, causing import to hang when the server was unreachable.

## Solution
Converted `_SaveFramesRequestNoValidate` from a module-level class to a lazily-initialized class created by the `_get_save_frames_request_no_validate()` function. This defers Session creation until the class is actually needed, not during import.

## Changes
- `clearml/backend_interface/datasets/hyper_dataset.py`: Created lazy initialization function
- `clearml/hyperdatasets/core.py`: Updated to use lazy function
- `clearml/backend_interface/datasets/__init__.py`: Export lazy function instead of class

## Testing
Verified that `import clearml` now completes in <1s even when the server is unreachable, instead of hanging indefinitely.

**Before fix:**
```bash
timeout 5 python -c "import clearml"
# Result: TIMEOUT (exit code 124)
```

**After fix:**
```bash
timeout 5 python -c "import clearml"
# Result: Success in 0.20s
```

## Test plan
- [x] Reproduced the bug locally
- [x] Implemented the fix
- [x] Verified `import clearml` completes quickly without server
- [x] Verified flake8 compliance for modified lines
- [ ] Maintainers: Verify CI tests pass
- [ ] Maintainers: Test with actual ClearML server usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)