### PR TITLE
fix(hydra): reload task data before fetching remote parameters

### DIFF
--- a/clearml/binding/hydra_bind.py
+++ b/clearml/binding/hydra_bind.py
@@ -107,6 +107,10 @@ class PatchHydra:
                 from ..task import Task
 
                 PatchHydra._current_task = Task.get_task(task_id=get_remote_task_id())
+            # Reload task data to ensure we have the latest parameters from the backend
+            # This is important when running remotely as the task may have been modified
+            # (e.g., cloned and edited) before being enqueued
+            PatchHydra._current_task.reload()
             # get the _parameter_allow_full_edit casted back to boolean
             connected_config = {}
             connected_config[PatchHydra._parameter_allow_full_edit] = False


### PR DESCRIPTION
## Related Issue

Fixes #1536

## Patch Description

When running remotely with Hydra, the task data needs to be reloaded to ensure we have the latest parameters from the backend. This is important because the task may have been modified (e.g., cloned and edited in the UI) before being enqueued for remote execution.

The issue manifested as Hydra overrides not being applied when using uv as the package manager. This was because the task was reading stale cached data that did not include the user's configuration changes made in the ClearML UI (such as setting `_allow_omegaconf_edit_ = True` and modifying the OmegaConf section).

## Root Cause

In `_patched_hydra_run`, when running remotely, the code retrieves the task and immediately tries to get parameters like `_allow_omegaconf_edit_`. However, the task object may have stale cached data from when it was first initialized. Without calling `reload()` to fetch the latest data from the backend, the code would use outdated parameter values, causing the Hydra configuration overrides to be ignored.

## Fix

Added a `reload()` call after getting the task object in `_patched_hydra_run` to ensure we have the latest task data from the backend before reading parameters.
