### PR TITLE
Raise duplicate InputModel import log from debug to info

### DIFF
--- a/clearml/model.py
+++ b/clearml/model.py
@@ -1699,7 +1699,7 @@ class InputModel(Model):
         if result.response.models:
             logger = get_logger()
 
-            logger.debug(f'A model with uri "{weights_url}" already exists. Selecting it')
+            logger.info(f'A model with uri "{weights_url}" already exists. Selecting it')
 
             model = get_single_result(
                 entity="model",


### PR DESCRIPTION
## Summary
Raise the duplicate-model import message in `InputModel.import_model()` from `DEBUG` to `INFO`.

## Why
When a model URL is already registered, ClearML reuses the existing model instead of importing a new one. This is an important user-facing event, and keeping it at `DEBUG` makes it easy to miss in normal usage.

Because debug logs are usually not enabled, the import can be skipped with no visible message. That makes it easy for users to assume a new model was registered, when ClearML actually selected an existing one.

## Change
- change `logger.debug(...)` to `logger.info(...)` for the duplicate URL selection message
- keep the existing `Selected model id: ...` info log unchanged
- no behavior or API changes

## Validation
- `python3 -m compileall clearml/model.py`
- `flake8` on `clearml/model.py`

## Notes
Running `flake8` on the whole repository surfaces pre-existing lint violations unrelated to this change.