### PR TITLE
Fix deprecation codecs.open() is deprecated. Use open() instead.

### DIFF
--- a/clearml/utilities/pigar/__main__.py
+++ b/clearml/utilities/pigar/__main__.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function, division, absolute_import
 
-import codecs
 import os
 from typing import Callable, Set, Optional, Tuple, List, Any
 
@@ -198,13 +197,13 @@ class GenerateReqs(object):
 
     def _save_old_reqs(self) -> None:
         if os.path.isfile(self._save_path):
-            with codecs.open(self._save_path, "rb", "utf-8") as f:
+            with open(self._save_path, "r", encoding="utf-8") as f:
                 self._old_reqs = f.readlines()
 
     def _reqs_diff(self) -> None:
         if not hasattr(self, "_old_reqs"):
             return
-        with codecs.open(self._save_path, "rb", "utf-8") as f:
+        with open(self._save_path, "r", encoding="utf-8") as f:
             new_reqs = f.readlines()
         is_diff, diffs = lines_diff(self._old_reqs, new_reqs)
         msg = "Requirements file has been covered, "

--- a/clearml/utilities/pyhocon/config_parser.py
+++ b/clearml/utilities/pyhocon/config_parser.py
@@ -3,7 +3,6 @@ import re
 import os
 import socket
 import contextlib
-import codecs
 from datetime import timedelta
 
 from pyparsing import Forward, Keyword, QuotedString, Word, Literal, Suppress, Regex, Optional, SkipTo, ZeroOrMore, \
@@ -95,7 +94,7 @@ class ConfigFactory(object):
         :type return: Config
         """
         try:
-            with codecs.open(filename, 'r', encoding=encoding) as fd:
+            with open(filename, 'r', encoding=encoding) as fd:
                 content = fd.read()
                 return cls.parse_string(content, os.path.dirname(filename), resolve, unresolved_value)
         except IOError as e:

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,10 @@ https://github.com/clearml/clearml
 import os.path
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages
-import codecs
 
 
 def read_text(filepath):
-    with codecs.open(filepath, "r", encoding="utf-8") as f:
+    with open(filepath, "r", encoding="utf-8") as f:
         return f.read()
 
 


### PR DESCRIPTION
Fix deprecation in 3.14:

```
codecs.open() is deprecated. Use open() instead.
```

`open` with `encoding` has been available since Python 3.