### PR TITLE
fix: Add check to avoid KeyError in dataset

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -2116,7 +2116,7 @@ class Dataset:
                 "tags": d.tags,
                 "version": d.runtime.get("version"),
             }
-            for d in datasets if d.project is not None
+            for d in datasets if d.project is not None and d.project in project_id_lookup
         ]
 
     def _add_files(


### PR DESCRIPTION
## Related Issue \ discussion

Issue: https://github.com/clearml/clearml/issues/1597

## Patch Description

The patch adds a check to the `Dataset.list_datasets()` function to check whether the key being passed to the dict in line #2114 slightly above exists in the dictionary. This makes sure that both the list and the dictionary have the same keys and there is no missmatch between them.

## Testing Instructions

This should pass all existing tests, since it doesnt add any existing logic and it is just a fail-safe mecanism to prevent `KeyError` happening. 

I have tested it myself and it works in fixing the issue and preventing KeyErrors from happening.

## Other Information

Happy to change if feedback is provided.