### PR TITLE
Revert "build(deps): bump transformers in /examples/advanced/model_finetuning (#1591)"

### DIFF
--- a/examples/advanced/model_finetuning/requirements.txt
+++ b/examples/advanced/model_finetuning/requirements.txt
@@ -1,4 +1,4 @@
 clearml==2.0.2
-transformers==5.0.0rc3
+transformers==4.53.0
 datasets==2.20.0
 peft==0.11.1


### PR DESCRIPTION
The version bump was accidental, this reverts it. It was not included in any release.