### PR TITLE
fix: adjust docstrings in clearml/task.py

### DIFF
--- a/clearml/task.py
+++ b/clearml/task.py
@@ -331,14 +331,14 @@ class Task(_Task):
             task.upload_artifact('myArtifact', d)
 
         .. note::
-            Call ``Task.init`` at the very beginning of your script's execution
+            Call ```Task.init``` at the very beginning of your script's execution
             (you can define classes and functions before that if needed).
-            The ``clearml`` code intercepts the execution done by your libraries such as pytorch,
+            The ```clearml``` code intercepts the execution done by your libraries such as pytorch,
             so if you execute code before initializing your task, this might lead to memory leaks,
             zombie child processes, etc.
 
-            An ideal location to call it is right after the ``if __name__ == "__main__":`` line
-            (assuming all your code execution is in this ``if`` statement block).
+            An ideal location to call it is right after the ```if __name__ == "__main__":``` line
+            (assuming all your code execution is in this ```if``` statement block).
 
         :param str project_name: The name of the project in which the experiment will be created. If the project does
             not exist, it is created. If ``project_name`` is ``None``, the repository name is used. (Optional)
@@ -3168,22 +3168,22 @@ class Task(_Task):
         config_dict: Optional[Mapping] = None,
     ) -> None:
         """
-        .. deprecated:: 0.14.1
-            Use ```Task.connect_configuration``` instead.
+        .. note::
+            This method is deprecated, use ```Task.connect_configuration```  instead.
         """
         self._set_model_config(config_text=config_text, config_dict=config_dict)
 
     def get_model_config_text(self) -> str:
         """
-        .. deprecated:: 0.14.1
-            Use ```Task.connect_configuration``` instead.
+        .. note::
+            This method is deprecated, use ```Task.connect_configuration```  instead.
         """
         return self._get_model_config_text()
 
     def get_model_config_dict(self) -> Dict:
         """
-        .. deprecated:: 0.14.1
-            Use ```Task.connect_configuration``` instead.
+        .. note::
+            This method is deprecated, use ```Task.connect_configuration```  instead.
         """
         return self._get_model_config_dict()
 


### PR DESCRIPTION
## Patch Description
We're making internal adjustments to the docstrings in `clearml/task.py` for the documentation at `clear.ml/docs`.