### PR TITLE
Refactor/clearml storage filepaths

### DIFF
--- a/clearml/backend_interface/metrics/events.py
+++ b/clearml/backend_interface/metrics/events.py
@@ -16,7 +16,7 @@ from six.moves.urllib.parse import urlparse, urlunparse
 from ...backend_api.services import events
 from ...config import deferred_config
 from ...debugging.log import LoggerRoot
-from ...storage.util import quote_url
+from ...storage.url import quote_url
 from ...utilities.attrs import attrs
 from ...utilities.process.mp import SingletonLock
 

--- a/clearml/binding/artifacts.py
+++ b/clearml/binding/artifacts.py
@@ -25,7 +25,7 @@ from ..backend_interface.metrics.events import UploadEvent
 from ..config import deferred_config, config
 from ..debugging.log import LoggerRoot
 from ..storage.helper import remote_driver_schemes
-from ..storage.util import get_common_path
+from ..storage.filepaths import get_common_path
 from ..storage.size import format_size
 from ..storage.hashing import sha256sum
 from ..utilities.process.mp import SafeEvent, ForkSafeRLock

--- a/clearml/model.py
+++ b/clearml/model.py
@@ -44,7 +44,7 @@ from .debugging.log import get_logger
 from .errors import UsageError
 from .storage.cache import CacheManager
 from .storage.helper import StorageHelper
-from .storage.util import get_common_path
+from .storage.filepaths import get_common_path
 from .utilities.enum import Options
 from .backend_interface import Task as _Task
 from .backend_interface.model import create_dummy_model, Model as _Model

--- a/clearml/storage/cache.py
+++ b/clearml/storage/cache.py
@@ -9,7 +9,7 @@ from typing import Union, Optional, Tuple, Dict
 from pathlib2 import Path
 
 from .helper import StorageHelper
-from .util import quote_url
+from .url import quote_url
 from ..config import get_cache_dir, deferred_config
 from ..debugging.log import LoggerRoot
 from ..utilities.files import get_filename_max_length
@@ -109,7 +109,7 @@ class CacheManager:
         def get_hashed_url_file(cls, url: str) -> str:
             str_hash = hashlib.md5(url.encode()).hexdigest()
             filename = url.split("/")[-1]
-            return "{}.{}".format(str_hash, quote_url(filename))
+            return f"{str_hash}.{quote_url(filename)}"
 
         def _conform_filename(self, file_name: str) -> str:
             """

--- a/clearml/storage/filepaths.py
+++ b/clearml/storage/filepaths.py
@@ -1,0 +1,72 @@
+import os
+from itertools import takewhile
+from typing import Optional, Union, Sequence
+
+from pathlib import Path
+
+
+def get_common_path(filepaths: Sequence[Union[str, Path]]) -> Optional[str]:
+    """
+    Return the common path of a list of file paths
+
+    :param filepaths: list of files (str or Path objects)
+    :return: Common path string (always absolute) or None if common path could not be found
+    """
+    if len(filepaths) == 0:
+        return None
+
+    abs_paths = [
+        Path(filepath).absolute().parent
+        for filepath in filepaths
+    ]
+
+    # Example: if filepaths = ["/a/b", "/c/d/e"], then `folder_names_by_depth = (("/", "/"), ("a","c"), ("b", "d"))`
+    # We don't need "e" in this example since it can't be in common with other paths that don't go that deep
+    folder_names_by_depth = zip(*(
+        path.parts
+        for path in abs_paths
+    ))
+
+    common_parts = [
+        level_parts[0]  # Folder name in the first path (since they're all equal)
+        for level_parts in takewhile(
+            lambda folder_names: len(set(folder_names)) == 1,
+            folder_names_by_depth,
+        )
+    ]
+
+    if len(common_parts) == 0:
+        return None
+
+    return Path(*common_parts).as_posix()
+
+
+def is_within_directory(directory: str, target: str) -> bool:
+    """
+    Checks if the 'target' path (formatted as a str) is within the suggested directory (also a str).
+    Converts paths to absolute paths by prefixing relative paths with the output of os.getcwd()
+    (via `os.path.abspath`), so that relative paths can be compared
+    on equal terms with other paths.
+
+    Examples:
+        is_within_directory("a", "a/b.txt") == True
+        is_within_directory("", "a/b.txt") == True
+        is_within_directory("a/b", "a/b/c/d.txt") == True
+        is_within_directory("a", "a.txt") == False # 'directory' variable refers to folder, not file
+        is_within_directory("a/b/c", "a/b/cd") == False # sibling directories with related names don't work
+        is_within_directory("a/b/cd", "a/b/ce") == False # sibling directories with related names don't work
+        is_within_directory("a/b/c/e", "a/b/cd") == False # sibling directories don't work
+
+    :param str target: Path to folder/file to check for containment in directory.
+    :param str directory: Path to folder to check for containment of target file/folder.
+    """
+    directory_absolute_path = Path(os.path.abspath(directory))
+    target_absolute_path = Path(os.path.abspath(target))
+
+    return (
+        len(target_absolute_path.parts) >= len(directory_absolute_path.parts)
+        and
+        directory_absolute_path.parts == (
+            target_absolute_path.parts[:len(directory_absolute_path.parts)]
+        )
+    )

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -62,7 +62,7 @@ from clearml.utilities.requests_toolbelt import (
     MultipartEncoder,
 )
 from .callbacks import UploadProgressReport, DownloadProgressReport
-from .util import quote_url
+from .url import quote_url
 from ..backend_api.session import Session
 from ..backend_api.utils import get_http_session_with_retry
 from ..backend_config.bucket_config import (
@@ -2995,7 +2995,11 @@ class _StorageHelper:
 
             # quote link
             def callback(result: bool) -> str:
-                return a_cb(quote_url(result_path, _StorageHelper._quotable_uri_schemes) if result else result)
+                return a_cb(
+                    quote_url(result_path, _StorageHelper._quotable_uri_schemes)
+                    if result
+                    else result
+                )
 
             # replace callback with wrapper
             cb = callback

--- a/clearml/storage/manager.py
+++ b/clearml/storage/manager.py
@@ -7,13 +7,14 @@ from random import random
 from time import time
 from typing import List, Optional, Union
 from zipfile import ZipFile
+from six.moves.urllib.parse import quote
 
 from pathlib2 import Path
 
 from .cache import CacheManager
 from .callbacks import ProgressReport
 from .helper import StorageHelper, StorageHelperDiskSpaceFileSizeStrategy
-from .util import encode_string_to_filename, safe_extract, create_zip_directories
+from .util import safe_extract, create_zip_directories
 from ..config import deferred_config
 from ..debugging.log import LoggerRoot
 
@@ -167,7 +168,11 @@ class StorageManager:
 
         cache_folder = Path(cache_path_encoding or cached_file).parent
         archive_suffix = (cache_path_encoding or cached_file).name[: -len(suffix)]
-        name = encode_string_to_filename(name) if name else name
+        name = (
+            quote(name, safe=" ")  # Encoding string to filename
+            if name
+            else name
+        )
         if target_folder:
             target_folder = Path(target_folder)
         else:

--- a/clearml/storage/url.py
+++ b/clearml/storage/url.py
@@ -1,0 +1,14 @@
+from typing import Sequence
+
+from six.moves.urllib.parse import quote, urlparse, urlunparse
+
+
+def quote_url(
+    url: str,
+    valid_schemes: Sequence[str] = ("http", "https"),
+) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme not in valid_schemes:
+        return url
+    parsed = parsed._replace(path=quote(parsed.path))
+    return str(urlunparse(parsed))

--- a/clearml/storage/util.py
+++ b/clearml/storage/util.py
@@ -1,11 +1,9 @@
 import fnmatch
 import os
 import sys
-from typing import Optional, Union, Sequence, Callable, Any
+from typing import Optional, Union, Callable, Any
 
-from pathlib2 import Path
-from six.moves.urllib.parse import quote, urlparse, urlunparse
-
+from .filepaths import is_within_directory
 from ..debugging.log import LoggerRoot
 
 
@@ -37,93 +35,11 @@ def get_config_object_matcher(**patterns: Any) -> Callable:
     return _matcher
 
 
-def quote_url(url: str, valid_schemes: Sequence[str] = ("http", "https")) -> str:
-    parsed = urlparse(url)
-    if parsed.scheme not in valid_schemes:
-        return url
-    parsed = parsed._replace(path=quote(parsed.path))
-    return str(urlunparse(parsed))
-
-
-def encode_string_to_filename(text: str) -> str:
-    return quote(text, safe=" ")
-
-
 def is_windows() -> bool:
     """
     :return: True if currently running on windows OS
     """
     return sys.platform == "win32"
-
-
-def get_common_path(list_of_files: Sequence[Union[str, Path]]) -> Optional[str]:
-    """
-    Return the common path of a list of files
-
-    :param list_of_files: list of files (str or Path objects)
-    :return: Common path string (always absolute) or None if common path could not be found
-    """
-    if not list_of_files:
-        return None
-
-    # a single file has its parent as common path
-    if len(list_of_files) == 1:
-        return Path(list_of_files[0]).absolute().parent.as_posix()
-
-    # find common path to support folder structure inside zip
-    common_path_parts = Path(list_of_files[0]).absolute().parts
-    for f in list_of_files:
-        f_parts = Path(f).absolute().parts
-        num_p = min(len(f_parts), len(common_path_parts))
-        if f_parts[:num_p] == common_path_parts[:num_p]:
-            common_path_parts = common_path_parts[:num_p]
-            continue
-        num_p = min([i for i, (a, b) in enumerate(zip(common_path_parts[:num_p], f_parts[:num_p])) if a != b] or [-1])
-        # no common path, break
-        if num_p < 0:
-            common_path_parts = []
-            break
-        # update common path
-        common_path_parts = common_path_parts[:num_p]
-
-    if common_path_parts:
-        common_path = Path()
-        for f in common_path_parts:
-            common_path /= f
-        return common_path.as_posix()
-
-    return None
-
-
-def is_within_directory(directory: str, target: str) -> bool:
-    """
-    Checks if the 'target' path (formatted as a str) is within the suggested directory (also a str).
-    Converts paths to absolute paths by prefixing relative paths with the output of os.getcwd()
-    (via `os.path.abspath`), so that relative paths can be compared
-    on equal terms with other paths.
-
-    Examples:
-        is_within_directory("a", "a/b.txt") == True
-        is_within_directory("", "a/b.txt") == True
-        is_within_directory("a/b", "a/b/c/d.txt") == True
-        is_within_directory("a", "a.txt") == False # 'directory' variable refers to folder, not file
-        is_within_directory("a/b/c", "a/b/cd") == False # sibling directories with related names don't work
-        is_within_directory("a/b/cd", "a/b/ce") == False # sibling directories with related names don't work
-        is_within_directory("a/b/c/e", "a/b/cd") == False # sibling directories don't work
-
-    :param str target: Path to folder/file to check for containment in directory.
-    :param str directory: Path to folder to check for containment of target file/folder.
-    """
-    directory_absolute_path = Path(os.path.abspath(directory))
-    target_absolute_path = Path(os.path.abspath(target))
-
-    return (
-        len(target_absolute_path.parts) >= len(directory_absolute_path.parts)
-        and
-        directory_absolute_path.parts == (
-            target_absolute_path.parts[:len(directory_absolute_path.parts)]
-        )
-    )
 
 
 def create_zip_directories(zipfile: Any, path: Optional[Union[str, os.PathLike]] = None) -> None:

--- a/clearml/storage/util.py
+++ b/clearml/storage/util.py
@@ -2,9 +2,21 @@ import fnmatch
 import os
 import sys
 from typing import Optional, Union, Callable, Any
+from six.moves.urllib.parse import quote
 
 from .filepaths import is_within_directory
 from ..debugging.log import LoggerRoot
+# Imports backwards compatibility
+from .filepaths import get_common_path  # noqa: F401
+from .hashing import (  # noqa: F401
+    sha256sum,
+    md5text,
+    crc32text,
+    hash_text,
+    hash_dict,
+)
+from .url import quote_url  # noqa: F401
+from .size import format_size, parse_size  # noqa: F401
 
 
 def get_config_object_matcher(**patterns: Any) -> Callable:
@@ -40,6 +52,13 @@ def is_windows() -> bool:
     :return: True if currently running on windows OS
     """
     return sys.platform == "win32"
+
+
+def encode_string_to_filename(text: str) -> str:
+    """
+    Encodes a string to be a valid filename.
+    """
+    return quote(text, safe=" ")
 
 
 def create_zip_directories(zipfile: Any, path: Optional[Union[str, os.PathLike]] = None) -> None:


### PR DESCRIPTION
## Patch Description
This refactors filepath-related functionality in its own file.
Also, a backwards-compatibility bug was introduced [in the last PR](https://github.com/clearml/clearml/pull/1605) related to the location of external imports, and it was fixed (see second commit). This bug has not been introduced in a release yet, so no issues there.