### PR TITLE
Refactor/clearml storage archive update

### DIFF
--- a/clearml/storage/archive.py
+++ b/clearml/storage/archive.py
@@ -1,0 +1,110 @@
+import os
+import tarfile
+from typing import Optional, Union, Any
+from pathlib import Path
+
+from .filepaths import is_within_directory
+from ..debugging.log import LoggerRoot
+
+
+def create_zip_directories(
+    zipfile: Any,
+    path: Optional[Union[str, os.PathLike]] = None,
+) -> None:
+    try:
+        path = os.getcwd() if path is None else os.fspath(path)
+        for member in zipfile.namelist():
+            arcname = member.replace("/", os.path.sep)
+            if os.path.altsep:
+                arcname = arcname.replace(os.path.altsep, os.path.sep)
+            # interpret absolute pathname as relative, remove drive letter or
+            # UNC path, redundant separators, "." and ".." components.
+            arcname = os.path.splitdrive(arcname)[1]
+            invalid_path_parts = ("", os.path.curdir, os.path.pardir)
+            arcname = os.path.sep.join(x for x in arcname.split(os.path.sep) if x not in invalid_path_parts)
+            if os.path.sep == "\\":
+                # noinspection PyBroadException
+                try:
+                    # filter illegal characters on Windows
+                    # noinspection PyProtectedMember
+                    arcname = zipfile._sanitize_windows_name(arcname, os.path.sep)
+                except Exception:
+                    pass
+
+            targetpath = os.path.normpath(os.path.join(path, arcname))
+
+            # Create all upper directories if necessary.
+            upperdirs = os.path.dirname(targetpath)
+            if upperdirs:
+                os.makedirs(upperdirs, exist_ok=True)
+    except Exception as e:
+        LoggerRoot.get_base_logger().warning("Failed creating zip directories: " + str(e))
+
+
+def extract_tar_archive(
+    archive_path: str,
+    suffix: str,  # Literal[".tar.gz", ".tgz"]
+    target: str = ".",
+    **kwargs: Any,
+) -> None:
+    """
+    Tarfile member sanitization (addresses CVE-2007-4559)
+    """
+    mode = {
+        ".tar.gz": "r",
+        ".tgz": "r:gz",
+    }[suffix]
+
+    with tarfile.open(archive_path, mode=mode) as tar_file:
+        base_dir = os.path.abspath(target)
+        for member in tar_file.getmembers():
+            flag_path_traversal_vulnerability(
+                extraction_folder=base_dir,
+                extraction_file_path=member.name,
+            )
+
+            if member.issym() or member.islnk():
+                flag_symlink_escape_vulnerability(
+                    extraction_folder=base_dir,
+                    extraction_file_path=member.name,
+                    extraction_symlink_target=member.linkname,
+                )
+
+        tar_file.extractall(path=base_dir, **kwargs)
+
+
+def flag_path_traversal_vulnerability(
+    extraction_folder: Union[str, Path],
+    extraction_file_path: Union[str, Path],
+) -> None:
+    """
+    Raises a ValueError if the extraction_file_path is not contained within the extraction_folder.
+    """
+    extraction_file_absolute_path = os.path.abspath(os.path.join(
+        extraction_folder,
+        extraction_file_path,
+    ))
+    if not is_within_directory(
+        extraction_folder,
+        extraction_file_absolute_path,
+    ):
+        raise ValueError(f"Path traversal detected in archive member: {extraction_file_path}")
+
+
+def flag_symlink_escape_vulnerability(
+    extraction_folder: Union[str, Path],
+    extraction_file_path: Union[str, Path],
+    extraction_symlink_target: Union[str, Path],
+) -> None:
+    """
+    Raises a ValueError if the extraction_symlink_target points outside of the extraction_folder.
+    """
+    extraction_link_absolute_path = os.path.abspath(os.path.join(
+        extraction_folder,
+        extraction_symlink_target,
+    ))
+    if not is_within_directory(
+        extraction_folder,
+        extraction_link_absolute_path,
+    ):
+        raise ValueError(f"Link target escapes extraction dir: {extraction_file_path} -> {extraction_symlink_target}")

--- a/clearml/storage/archive.py
+++ b/clearml/storage/archive.py
@@ -1,44 +1,33 @@
 import os
 import tarfile
-from typing import Optional, Union, Any
+from typing import Union, Any
 from pathlib import Path
+from zipfile import ZipFile
 
 from .filepaths import is_within_directory
-from ..debugging.log import LoggerRoot
 
 
-def create_zip_directories(
-    zipfile: Any,
-    path: Optional[Union[str, os.PathLike]] = None,
+def extract_zip_archive(
+    archive_path: str,
+    target: str = ".",
 ) -> None:
-    try:
-        path = os.getcwd() if path is None else os.fspath(path)
-        for member in zipfile.namelist():
-            arcname = member.replace("/", os.path.sep)
-            if os.path.altsep:
-                arcname = arcname.replace(os.path.altsep, os.path.sep)
-            # interpret absolute pathname as relative, remove drive letter or
-            # UNC path, redundant separators, "." and ".." components.
-            arcname = os.path.splitdrive(arcname)[1]
-            invalid_path_parts = ("", os.path.curdir, os.path.pardir)
-            arcname = os.path.sep.join(x for x in arcname.split(os.path.sep) if x not in invalid_path_parts)
-            if os.path.sep == "\\":
-                # noinspection PyBroadException
-                try:
-                    # filter illegal characters on Windows
-                    # noinspection PyProtectedMember
-                    arcname = zipfile._sanitize_windows_name(arcname, os.path.sep)
-                except Exception:
-                    pass
+    """
+    Extracts a .zip archive file to a target location.
 
-            targetpath = os.path.normpath(os.path.join(path, arcname))
+    :param str archive_path: The path to the .zip archive file.
+    :param str target: The location in the filesystem where the contents of the .zip archive should be extracted.
+    """
+    with ZipFile(file=archive_path, mode='r') as zip_file:
+        base_directory = os.path.abspath(target)
+        for file_path in zip_file.namelist():
+            flag_path_traversal_vulnerability(
+                extraction_folder=base_directory,
+                extraction_file_path=file_path,
+            )
+            # No need to run flag_symlink_escape_vulnerability
+            # zip_file.extractall does not create symlinks
 
-            # Create all upper directories if necessary.
-            upperdirs = os.path.dirname(targetpath)
-            if upperdirs:
-                os.makedirs(upperdirs, exist_ok=True)
-    except Exception as e:
-        LoggerRoot.get_base_logger().warning("Failed creating zip directories: " + str(e))
+        zip_file.extractall(path=target)
 
 
 def extract_tar_archive(
@@ -48,14 +37,19 @@ def extract_tar_archive(
     **kwargs: Any,
 ) -> None:
     """
+    Extracts a .tar.gz or .tgz archive file to a target location after sanitization of the archive's contents.
     Tarfile member sanitization (addresses CVE-2007-4559)
+
+    :param str archive_path: The path to the tar archive file.
+    :param str suffix: The full extension of the tar file. Either '.tar.gz' or '.tgz'.
+    :param str target: The location in the filesystem where the contents of the tar archive should be extracted.
     """
     mode = {
         ".tar.gz": "r",
         ".tgz": "r:gz",
     }[suffix]
 
-    with tarfile.open(archive_path, mode=mode) as tar_file:
+    with tarfile.open(name=archive_path, mode=mode) as tar_file:
         base_dir = os.path.abspath(target)
         for member in tar_file.getmembers():
             flag_path_traversal_vulnerability(

--- a/clearml/storage/manager.py
+++ b/clearml/storage/manager.py
@@ -1,7 +1,6 @@
 import fnmatch
 import logging
 import shutil
-import tarfile
 from multiprocessing.pool import ThreadPool
 from random import random
 from time import time
@@ -14,7 +13,7 @@ from pathlib2 import Path
 from .cache import CacheManager
 from .callbacks import ProgressReport
 from .helper import StorageHelper, StorageHelperDiskSpaceFileSizeStrategy
-from .util import safe_extract, create_zip_directories
+from .archive import extract_tar_archive, create_zip_directories
 from ..config import deferred_config
 from ..debugging.log import LoggerRoot
 
@@ -203,12 +202,12 @@ class StorageManager:
                 zip_file = ZipFile(cached_file.as_posix())
                 create_zip_directories(zip_file, path=temp_target_folder.as_posix())
                 zip_file.extractall(path=temp_target_folder.as_posix())
-            elif suffix == ".tar.gz":
-                with tarfile.open(cached_file.as_posix()) as file:
-                    safe_extract(file, temp_target_folder.as_posix())
-            elif suffix == ".tgz":
-                with tarfile.open(cached_file.as_posix(), mode="r:gz") as file:
-                    safe_extract(file, temp_target_folder.as_posix())
+            elif suffix in (".tar.gz", ".tgz"):
+                extract_tar_archive(
+                    archive_path=cached_file.as_posix(),
+                    target=temp_target_folder.as_posix(),
+                    suffix=suffix,
+                )
 
             if temp_target_folder != target_folder:
                 # we assume we will have such folder if we already extract the file

--- a/clearml/storage/manager.py
+++ b/clearml/storage/manager.py
@@ -5,7 +5,6 @@ from multiprocessing.pool import ThreadPool
 from random import random
 from time import time
 from typing import List, Optional, Union
-from zipfile import ZipFile
 from six.moves.urllib.parse import quote
 
 from pathlib2 import Path
@@ -13,7 +12,7 @@ from pathlib2 import Path
 from .cache import CacheManager
 from .callbacks import ProgressReport
 from .helper import StorageHelper, StorageHelperDiskSpaceFileSizeStrategy
-from .archive import extract_tar_archive, create_zip_directories
+from .archive import extract_tar_archive, extract_zip_archive
 from ..config import deferred_config
 from ..debugging.log import LoggerRoot
 
@@ -172,12 +171,11 @@ class StorageManager:
             if name
             else name
         )
-        if target_folder:
-            target_folder = Path(target_folder)
-        else:
-            target_folder = cache_folder / CacheManager.get_context_folder_lookup(cache_context).format(
-                archive_suffix, name
-            )
+        target_folder = (
+            Path(target_folder)
+            if target_folder
+            else cache_folder / CacheManager.get_context_folder_lookup(cache_context).format(archive_suffix, name)
+        )
 
         if target_folder.is_dir() and not force:
             # noinspection PyBroadException
@@ -190,18 +188,18 @@ class StorageManager:
         base_logger = LoggerRoot.get_base_logger()
         try:
             # if target folder exists, meaning this is forced ao we extract directly into target folder
-            if target_folder.is_dir():
-                temp_target_folder = target_folder
-            else:
-                temp_target_folder = cache_folder / "{0}_{1}_{2}".format(
-                    target_folder.name, time() * 1000, str(random()).replace(".", "")
-                )
-                temp_target_folder.mkdir(parents=True, exist_ok=True)
+            temp_target_folder = (
+                target_folder
+                if target_folder.is_dir()
+                else cache_folder / f"{target_folder.name}_{time() * 1000}_{str(random()).replace('.', '')}"
+            )
+            temp_target_folder.mkdir(parents=True, exist_ok=True)
 
             if suffix == ".zip":
-                zip_file = ZipFile(cached_file.as_posix())
-                create_zip_directories(zip_file, path=temp_target_folder.as_posix())
-                zip_file.extractall(path=temp_target_folder.as_posix())
+                extract_zip_archive(
+                    archive_path=cached_file.as_posix(),
+                    target=temp_target_folder.as_posix(),
+                )
             elif suffix in (".tar.gz", ".tgz"):
                 extract_tar_archive(
                     archive_path=cached_file.as_posix(),
@@ -221,17 +219,17 @@ class StorageManager:
                         target_folder.touch(exist_ok=True)
                     else:
                         base_logger.warning(
-                            "Failed renaming {0} to {1}".format(temp_target_folder.as_posix(), target_folder.as_posix())
+                            f"Failed renaming {temp_target_folder.as_posix()} to {target_folder.as_posix()}"
                         )
                     try:
                         shutil.rmtree(temp_target_folder.as_posix())
                     except Exception as ex:
                         base_logger.warning(
-                            "Exception {}\nFailed deleting folder {}".format(ex, temp_target_folder.as_posix())
+                            f"Exception {ex}\nFailed deleting folder {temp_target_folder.as_posix()}"
                         )
         except Exception as ex:
             # failed extracting the file:
-            base_logger.warning("Exception {}\nFailed extracting zip file {}".format(ex, cached_file.as_posix()))
+            base_logger.warning(f"Exception {ex}\nFailed extracting zip file {cached_file.as_posix()}")
             # noinspection PyBroadException
             try:
                 target_folder.rmdir()
@@ -468,7 +466,7 @@ class StorageManager:
                 remote_path = (
                     str(Path(helper.base_url) / Path(path))
                     if helper.get_driver_direct_access(helper.base_url)
-                    else "{}/{}".format(helper.base_url.rstrip("/"), path.lstrip("/"))
+                    else f"{helper.base_url.rstrip('/')}/{path.lstrip('/')}"
                 )
                 if match_wildcard and not fnmatch.fnmatch(remote_path, match_wildcard):
                     continue
@@ -486,7 +484,7 @@ class StorageManager:
             for res in results:
                 res.wait()
         if not results and not silence_errors:
-            LoggerRoot.get_base_logger().warning("Did not download any files matching {}".format(remote_url))
+            LoggerRoot.get_base_logger().warning(f"Did not download any files matching {remote_url}")
         return local_folder
 
     @classmethod
@@ -519,20 +517,20 @@ class StorageManager:
         try:
             helper_list_result = helper.list(prefix=remote_url, with_metadata=with_metadata)
         except Exception as ex:
-            LoggerRoot.get_base_logger().warning("Can not list files for '{}' - {}".format(remote_url, ex))
+            LoggerRoot.get_base_logger().warning(f"Can not list files for '{remote_url}' - {ex}")
             return None
 
         prefix = remote_url.rstrip("/") if helper.base_url == "file://" else helper.base_url
         if not with_metadata:
             return (
-                ["{}/{}".format(prefix, name) for name in helper_list_result]
+                [f"{prefix}/{name}" for name in helper_list_result]
                 if return_full_path
                 else helper_list_result
             )
         else:
             if return_full_path:
                 for obj in helper_list_result:
-                    obj["name"] = "{}/{}".format(prefix, obj.get("name"))
+                    obj["name"] = f"{prefix}/{obj.get('name')}"
             return helper_list_result
 
     @classmethod

--- a/clearml/storage/util.py
+++ b/clearml/storage/util.py
@@ -14,7 +14,7 @@ from .hashing import (  # noqa: F401
 )
 from .url import quote_url  # noqa: F401
 from .size import format_size, parse_size  # noqa: F401
-from .archive import extract_tar_archive as safe_extract, create_zip_directories  # noqa: F401
+from .archive import extract_tar_archive as safe_extract  # noqa: F401
 
 
 def get_config_object_matcher(**patterns: Any) -> Callable:

--- a/clearml/storage/util.py
+++ b/clearml/storage/util.py
@@ -1,11 +1,8 @@
 import fnmatch
-import os
 import sys
-from typing import Optional, Union, Callable, Any
+from typing import Optional, Callable, Any
 from six.moves.urllib.parse import quote
 
-from .filepaths import is_within_directory
-from ..debugging.log import LoggerRoot
 # Imports backwards compatibility
 from .filepaths import get_common_path  # noqa: F401
 from .hashing import (  # noqa: F401
@@ -17,6 +14,7 @@ from .hashing import (  # noqa: F401
 )
 from .url import quote_url  # noqa: F401
 from .size import format_size, parse_size  # noqa: F401
+from .archive import extract_tar_archive as safe_extract, create_zip_directories  # noqa: F401
 
 
 def get_config_object_matcher(**patterns: Any) -> Callable:
@@ -57,56 +55,6 @@ def is_windows() -> bool:
 def encode_string_to_filename(text: str) -> str:
     """
     Encodes a string to be a valid filename.
+    return quote(text, safe=" ")
     """
     return quote(text, safe=" ")
-
-
-def create_zip_directories(zipfile: Any, path: Optional[Union[str, os.PathLike]] = None) -> None:
-    try:
-        path = os.getcwd() if path is None else os.fspath(path)
-        for member in zipfile.namelist():
-            arcname = member.replace("/", os.path.sep)
-            if os.path.altsep:
-                arcname = arcname.replace(os.path.altsep, os.path.sep)
-            # interpret absolute pathname as relative, remove drive letter or
-            # UNC path, redundant separators, "." and ".." components.
-            arcname = os.path.splitdrive(arcname)[1]
-            invalid_path_parts = ("", os.path.curdir, os.path.pardir)
-            arcname = os.path.sep.join(x for x in arcname.split(os.path.sep) if x not in invalid_path_parts)
-            if os.path.sep == "\\":
-                # noinspection PyBroadException
-                try:
-                    # filter illegal characters on Windows
-                    # noinspection PyProtectedMember
-                    arcname = zipfile._sanitize_windows_name(arcname, os.path.sep)
-                except Exception:
-                    pass
-
-            targetpath = os.path.normpath(os.path.join(path, arcname))
-
-            # Create all upper directories if necessary.
-            upperdirs = os.path.dirname(targetpath)
-            if upperdirs:
-                os.makedirs(upperdirs, exist_ok=True)
-    except Exception as e:
-        LoggerRoot.get_base_logger().warning("Failed creating zip directories: " + str(e))
-
-
-def safe_extract(
-    tar: Any,
-    path: str = ".",
-    members: Any = None,
-    numeric_owner: bool = False,
-) -> None:
-    """Tarfile member sanitization (addresses CVE-2007-4559)"""
-    base_dir = os.path.abspath(path)
-    for member in tar.getmembers():
-        member_path = os.path.abspath(os.path.join(base_dir, member.name))
-        if not is_within_directory(base_dir, member_path):
-            raise Exception("Path traversal detected in archive member: {}".format(member.name))
-
-        if member.issym() or member.islnk():
-            link_target = os.path.abspath(os.path.join(base_dir, member.linkname))
-            if not is_within_directory(base_dir, link_target):
-                raise Exception("Link target escapes extraction dir: {} -> {}".format(member.name, member.linkname))
-    tar.extractall(path=base_dir, members=members, numeric_owner=numeric_owner)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
-
-flake8-bugbear~=21.4
-flake8~=3.9
-pytest~=6.2
+-r lint-requirements.txt
+pytest>=8.3.5 ; python_version < '3.9'
+pytest>=8.4.2 ; python_version >= '3.9' and python_version < '3.10'
+pytest>=9.0.3 ; python_version >= '3.10'
+packaging>=26.2

--- a/examples/hyperdatasets/create_doc_entries.py
+++ b/examples/hyperdatasets/create_doc_entries.py
@@ -182,7 +182,7 @@ def main() -> None:
             break
 
     if not documents:
-        raise ValueError(f"No Markdown files found under {docs_dir}")
+        raise ValueError(f"No Markdown files found in the urls {urls}")
 
     embeddings = None
     if args.embed:

--- a/examples/hyperdatasets/requirements.txt
+++ b/examples/hyperdatasets/requirements.txt
@@ -2,6 +2,7 @@ clearml>=2.1.0
 accelerate==1.12.0
 peft==0.18.1
 Pillow
+sentence-transformers==5.3.0
 torch==2.10.0+cu130
 torchaudio==2.10.0+cu130
 torchvision==0.25.0+cu130


### PR DESCRIPTION
## Patch Description
This PR adds improvements to the `clearml/storage` directory.
- Refactor of `clearml/storage/util.py` to produce `clearml/storage/archive.py` for functions related to extracting `.tar.gz`, `.tgz` and `.zip` files contents.
- Removal of redundant code from the `create_zip_directories` function. This code was duplicated from the `zipfile` package from the Python standard library with useless `try-except` safeguards, because the call to `ZipFile().extractall` done right after would execute the same code without the safeguard, resulting in the same errors.
- Minor improvements to `examples/hyperdatasets`.