### PR TITLE
Hash comparison, subset file pulling, prune stale link entries

### DIFF
--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy, copy
 from multiprocessing.pool import ThreadPool
 from tempfile import mkdtemp
-from typing import Union, Optional, Sequence, List, Dict, Mapping, Tuple, TYPE_CHECKING, Any
+from typing import Union, Optional, Sequence, List, Dict, Mapping, Tuple, TYPE_CHECKING, Any, Set
 from zipfile import ZIP_DEFLATED
 from collections import deque
 
@@ -115,6 +115,7 @@ class LinkEntry:
             relative_path=self.relative_path,
             parent_dataset_id=self.parent_dataset_id,
             size=self.size,
+            hash=self.hash,
         )
 
 
@@ -482,6 +483,7 @@ class Dataset:
         recursive: bool = True,
         verbose: bool = False,
         max_workers: Optional[int] = None,
+        read_hash: bool = False,
     ) -> int:
         """
         Adds external files or folders to the current dataset.
@@ -515,6 +517,11 @@ class Dataset:
         :param verbose: If True, print to console files added/modified
         :param max_workers: The number of threads to add the external files with. Useful when `source_url` is
             a sequence. Defaults to the number of logical cores
+        :param read_hash: If True, read the SHA-256 hash from each object's custom cloud metadata and store it
+            on the resulting LinkEntry. When available, hash comparison is used for change detection instead of
+            file size. Only effective for objects uploaded with ``upload_hash`` set in the StorageHelper extra dict.
+            Defaults to False.
+
         :return: Number of file links added
         """
         self._dirty = True
@@ -542,6 +549,7 @@ class Dataset:
                         dataset_path=dataset_path_,
                         recursive=recursive,
                         verbose=verbose,
+                        read_hash=read_hash,
                     )
                 )
         for future_ in futures_:
@@ -663,6 +671,10 @@ class Dataset:
         num_files = len(self._dataset_file_entries)
         self._dataset_file_entries = {k: f for k, f in self._dataset_file_entries.items() if filter_f(f)}
         num_removed = num_files - len(self._dataset_file_entries)
+        # also prune stale link entries
+        num_links = len(self._dataset_link_entries)
+        self._dataset_link_entries = {k: v for k, v in self._dataset_link_entries.items() if filter_f(v)}
+        num_removed += num_links - len(self._dataset_link_entries)
         # Update the internal state
         self.update_changed_files(num_files_removed=num_removed)
 
@@ -699,6 +711,7 @@ class Dataset:
         max_workers: Optional[int] = None,
         retries: int = 3,
         preview: bool = True,
+        upload_as_external_links: bool = False,
     ) -> Optional[bool]:
         """
         Start file uploading, the function returns when all files are uploaded.
@@ -718,6 +731,10 @@ class Dataset:
           - number of logical cores: otherwise
         :param int retries: Number of retries before failing to upload each zip. If 0, the upload is not retried.
         :param preview: If True (defaul) the dataset preview is uploaded and shown in the UI.
+        :param upload_as_external_links: If True, upload each local file entry directly to storage
+            as an individual object (instead of bundling into a zip artifact) and register it as an
+            external link entry. The destination path is ``<output_url>/external_links/<dataset_id>/``.
+            Requires ``output_url`` to be set (either as argument or as the task's output URI).
 
         :raise: If the upload failed (i.e. at least one zip failed to upload), raise a `ValueError`
         """
@@ -739,6 +756,48 @@ class Dataset:
                 if self._task.output_uri and self._task.output_uri.startswith(tuple(cloud_driver_schemes))
                 else psutil.cpu_count()
             )
+
+        if upload_as_external_links:
+            self._task.get_logger().report_text(
+                "Uploading dataset files as external links: {}".format(
+                    dict(
+                        show_progress=show_progress,
+                        verbose=verbose,
+                        output_url=output_url,
+                        compression=compression,
+                    )
+                ),
+                print_console=False,
+            )
+            dest_url = self.get_default_storage()
+            if not dest_url:
+                raise ValueError("output_url must be set when upload_as_external_links=True")
+            dest_bucket_dir = "{}/external_links/{}".format(dest_url.rstrip("/"), self._id)
+            files_to_upload = [
+                (f.local_path, "{}/{}".format(dest_bucket_dir, f.relative_path), f.hash)
+                for f in self._dataset_file_entries.values()
+                if f.local_path
+            ]
+            if files_to_upload:
+                effective_workers = max_workers or (
+                    1 if dest_url.startswith(tuple(cloud_driver_schemes)) else psutil.cpu_count()
+                )
+
+                def _upload_single(args):
+                    local_path, remote_path, file_hash = args
+                    helper = StorageHelper.get(remote_path)
+                    if helper is None:
+                        raise ValueError("No storage helper available for: {}".format(remote_path))
+                    helper.upload(
+                        src_path=local_path,
+                        dest_path=remote_path,
+                        extra={"upload_hash": file_hash} if file_hash else None,
+                    )
+
+                with ThreadPoolExecutor(max_workers=effective_workers) as _pool:
+                    list(_pool.map(_upload_single, files_to_upload))
+            self._dataset_file_entries = {}
+            self.add_external_files(dest_bucket_dir, read_hash=True)
 
         self._task.get_logger().report_text(
             "Uploading dataset files: {}".format(
@@ -872,6 +931,7 @@ class Dataset:
             verbose=verbose,
             output_url=output_url,
             compression=compression,
+            upload_as_external_links=upload_as_external_links,
         )
 
         self._dirty = False
@@ -1015,6 +1075,7 @@ class Dataset:
         num_parts: Optional[int] = None,
         raise_on_error: bool = True,
         max_workers: Optional[int] = None,
+        files: Optional[List[str]] = None,
     ) -> str:
         """
         Return a base folder with a read-only (immutable) local copy of the entire dataset
@@ -1035,6 +1096,10 @@ class Dataset:
         :param raise_on_error: If True, raise exception if dataset merging failed on any file
         :param max_workers: Number of threads to be spawned when getting the dataset copy. Defaults
             to the number of logical cores.
+        :param files: Optional list of relative file paths to pull. When provided, only those files
+            (and the chunks that contain them) are downloaded. The local cache folder is suffixed
+            with a short hash of the file list so it is stored independently from the full dataset
+            copy. When None (default), the full dataset is downloaded.
 
         :return: A base folder for the entire dataset
         """
@@ -1048,6 +1113,8 @@ class Dataset:
             raise ValueError("Cannot get a local copy of a dataset that was not finalized/closed")
         max_workers = max_workers or psutil.cpu_count()
 
+        files_of_interest = set(files) if files else None
+
         # now let's merge the parents
         target_folder = self._merge_datasets(
             use_soft_links=use_soft_links,
@@ -1055,6 +1122,7 @@ class Dataset:
             part=part,
             num_parts=num_parts,
             max_workers=max_workers,
+            files_of_interest=files_of_interest,
         )
         return target_folder
 
@@ -2228,11 +2296,13 @@ class Dataset:
         for f in file_entries:
             ds_cur_f = self._dataset_file_entries.get(f.relative_path)
             if not ds_cur_f:
-                if (
-                    f.relative_path in self._dataset_link_entries
-                    and f.size == self._dataset_link_entries[f.relative_path].size
-                ):
-                    continue
+                existing_link = self._dataset_link_entries.get(f.relative_path)
+                if existing_link is not None:
+                    same = (existing_link.hash and f.hash and existing_link.hash == f.hash) or (
+                        not existing_link.hash and f.size == existing_link.size
+                    )
+                    if same:
+                        continue
                 # de-duplication: if a previous file (possibly removed earlier in sync) has the same content hash,
                 # reuse its storage reference to avoid re-uploading
                 if f.hash and f.hash in prev_hash_lookup:
@@ -2243,11 +2313,16 @@ class Dataset:
                     # if the previous entry already pointed to uploaded content (no local_path), skip uploading again
                     if getattr(prev_fe, "local_path", None) is None and prev_fe.artifact_name:
                         f.local_path = None
-                if verbose:
-                    self._task.get_logger().report_text("Add {}".format(f.relative_path))
                 self._dataset_file_entries[f.relative_path] = f
                 if f.relative_path not in self._dataset_link_entries:
-                    count += 1
+                    if verbose:
+                        self._task.get_logger().report_text("Add {}".format(f.relative_path))
+                else:
+                    modified_count += 1
+                    if verbose:
+                        self._task.get_logger().report_text("Modified {}".format(f.relative_path))
+                count += 1
+
             elif ds_cur_f.hash != f.hash:
                 if verbose:
                     self._task.get_logger().report_text("Modified {}".format(f.relative_path))
@@ -2694,9 +2769,12 @@ class Dataset:
         part: Optional[int] = None,
         num_parts: Optional[int] = None,
         lock_target_folder: bool = True,
+        subset_hash: Optional[str] = None,
     ) -> Tuple[Path, CacheManager.CacheContext]:
         cache = CacheManager.get_cache_manager(cache_context=self.__cache_context)
-        local_folder = Path(cache.get_cache_folder()) / self._get_cache_folder_name(part=part, num_parts=num_parts)
+        local_folder = Path(cache.get_cache_folder()) / self._get_cache_folder_name(
+            part=part, num_parts=num_parts, subset_hash=subset_hash
+        )
         if lock_target_folder:
             cache.lock_cache_folder(local_folder)
         local_folder.mkdir(parents=True, exist_ok=True)
@@ -2733,6 +2811,7 @@ class Dataset:
         part: Optional[int] = None,
         num_parts: Optional[int] = None,
         max_workers: Optional[int] = None,
+        files_of_interest: Optional[Set[str]] = None,
     ) -> str:
         """
         download and copy / soft-link, files from all the parent dataset versions
@@ -2748,9 +2827,14 @@ class Dataset:
             part=0 -> chunks[0,5], part=1 -> chunks[1,6], part=2 -> chunks[2,7], part=3 -> chunks[3, ]
         :param max_workers: Number of threads to be spawned when merging datasets. Defaults to the number
             of logical cores.
+        :param files_of_interest: Optional set of relative file paths. When provided, only those files
+            (and the chunks that contain them) are downloaded. The cache folder is suffixed with a short
+            hash derived from this set.
 
         :return: the target folder
         """
+        import hashlib
+
         assert part is None or (isinstance(part, int) and part >= 0)
         assert num_parts is None or (isinstance(num_parts, int) and num_parts >= 1)
 
@@ -2762,15 +2846,40 @@ class Dataset:
         if part is not None and not num_parts:
             num_parts = self.get_num_chunks()
 
-        # just create the dataset target folder
-        target_base_folder, _ = self._create_ds_target_folder(part=part, num_parts=num_parts, lock_target_folder=True)
+        # compute a deterministic 8-char suffix when a file subset is requested
+        subset_hash = None
+        link_entries_of_interest = None
+        if files_of_interest:
+            subset_hash = hashlib.sha256(
+                "\n".join(sorted(files_of_interest)).encode()
+            ).hexdigest()[:8]
+            link_entries_of_interest = {
+                k: v for k, v in self._dataset_link_entries.items() if k in files_of_interest
+            }
 
-        # selected specific chunks if `part` was passed
-        chunk_selection = None if part is None else self._build_chunk_selection(part=part, num_parts=num_parts)
+        # just create the dataset target folder
+        target_base_folder, _ = self._create_ds_target_folder(
+            part=part, num_parts=num_parts, lock_target_folder=True, subset_hash=subset_hash
+        )
+
+        # selected specific chunks if `part` was passed, or subset of files was requested
+        if files_of_interest:
+            chunk_selection = self._build_subset_chunk_selection(files_of_interest)
+            # if all requested files are link entries (no chunk-backed files), no chunk
+            # filtering is needed — fall back to None so the current dataset is still included
+            # in dependencies_by_order and its link entries can be downloaded.
+            if not chunk_selection:
+                chunk_selection = None
+        elif part is not None:
+            chunk_selection = self._build_chunk_selection(part=part, num_parts=num_parts)
+        else:
+            chunk_selection = None
 
         # check if target folder is not empty, see if it contains everything we need
         if target_base_folder and next(target_base_folder.iterdir(), None):
-            if self._verify_dataset_folder(target_base_folder, part, chunk_selection, max_workers):
+            if self._verify_dataset_folder(
+                target_base_folder, part, chunk_selection, max_workers, files_of_interest=files_of_interest
+            ):
                 target_base_folder.touch()
                 self._release_lock_ds_target_folder(target_base_folder)
                 return target_base_folder.as_posix()
@@ -2781,7 +2890,7 @@ class Dataset:
                 # make sure we recreate the dataset target folder
                 target_base_folder.mkdir(parents=True, exist_ok=True)
 
-        # get the dataset dependencies (if `part` was passed, only selected the ones in the selected part)
+        # get the dataset dependencies (if `part` was passed or subset requested, only select relevant ones)
         dependencies_by_order = (
             self._get_dependencies_by_order(include_unused=False, include_current=True)
             if chunk_selection is None
@@ -2796,6 +2905,7 @@ class Dataset:
                 cleanup_target_folder=True,
                 target_folder=target_base_folder,
                 max_workers=max_workers,
+                link_entries_of_interest=link_entries_of_interest,
             )
             dependencies_by_order.remove(self._id)
 
@@ -2815,10 +2925,13 @@ class Dataset:
             use_soft_links=use_soft_links,
             raise_on_error=False,
             force=False,
+            files_of_interest=files_of_interest,
         )
 
         # verify entire dataset (if failed, force downloading parent datasets)
-        if not self._verify_dataset_folder(target_base_folder, part, chunk_selection, max_workers):
+        if not self._verify_dataset_folder(
+            target_base_folder, part, chunk_selection, max_workers, files_of_interest=files_of_interest
+        ):
             LoggerRoot.get_base_logger().info("Dataset parents need refreshing, re-fetching all parent datasets")
             # we should delete the entire cache folder
             self._extract_parent_datasets(
@@ -2828,6 +2941,7 @@ class Dataset:
                 use_soft_links=use_soft_links,
                 raise_on_error=raise_on_error,
                 force=True,
+                files_of_interest=files_of_interest,
             )
 
         self._release_lock_ds_target_folder(target_base_folder)
@@ -3076,7 +3190,35 @@ class Dataset:
         )
         return dict(chunks_lookup)
 
-    def _get_cache_folder_name(self, part: Optional[int] = None, num_parts: Optional[int] = None) -> str:
+    def _build_subset_chunk_selection(self, files_of_interest: Set[str]) -> Dict[str, List[int]]:
+        """
+        Build a chunk_selection dict covering only the chunks that contain at least one file
+        from files_of_interest, across all datasets in the dependency graph.
+        :return: Dict mapping dataset_id to list of chunk indices needed for the requested files.
+        """
+        result = {}  # type: Dict[str, List[int]]
+        for ds_id in [self._id] + list(self._dependency_graph.keys()):
+            ds = self if ds_id == self._id else Dataset.get(dataset_id=ds_id)
+            for rel_path, entry in ds._dataset_file_entries.items():
+                if rel_path not in files_of_interest:
+                    continue
+                chunk_idx = self._get_chunk_idx_from_artifact_name(entry.artifact_name)
+                if chunk_idx < 0:
+                    continue
+                if ds_id not in result:
+                    result[ds_id] = []
+                if chunk_idx not in result[ds_id]:
+                    result[ds_id].append(chunk_idx)
+        return result
+
+    def _get_cache_folder_name(
+        self,
+        part: Optional[int] = None,
+        num_parts: Optional[int] = None,
+        subset_hash: Optional[str] = None,
+    ) -> str:
+        if subset_hash:
+            return "{}{}_{}".format(self.__cache_folder_prefix, self._id, subset_hash)
         if part is None:
             return "{}{}".format(self.__cache_folder_prefix, self._id)
         return "{}{}_{}_{}".format(self.__cache_folder_prefix, self._id, part, num_parts)
@@ -3504,10 +3646,16 @@ class Dataset:
         raise_on_error: bool,
         force: bool,
         max_workers: Optional[int] = None,
+        files_of_interest: Optional[Set[str]] = None,
     ) -> None:
         # create thread pool, for creating soft-links / copying
         max_workers = max_workers or psutil.cpu_count()
         pool = ThreadPool(max_workers)
+        link_entries_of_interest = (
+            {k: v for k, v in self._dataset_link_entries.items() if k in files_of_interest}
+            if files_of_interest
+            else self._dataset_link_entries
+        )
         for dataset_version_id in dependencies_by_order:
             # make sure we skip over empty dependencies
             if dataset_version_id not in self._dependency_graph:
@@ -3522,7 +3670,7 @@ class Dataset:
                     lock_target_folder=True,
                     cleanup_target_folder=False,
                     max_workers=max_workers,
-                    link_entries_of_interest=self._dataset_link_entries,
+                    link_entries_of_interest=link_entries_of_interest,
                 )
             )
             ds_base_folder.touch()
@@ -3532,6 +3680,8 @@ class Dataset:
                     selected_chunks is not None
                     and self._get_chunk_idx_from_artifact_name(file_entry.artifact_name) not in selected_chunks
                 ):
+                    return
+                if files_of_interest and file_entry.relative_path not in files_of_interest:
                     return
                 source = (ds_base_folder / file_entry.relative_path).as_posix()
                 target = (target_base_folder / file_entry.relative_path).as_posix()
@@ -3580,6 +3730,7 @@ class Dataset:
         part: int,
         chunk_selection: dict,
         max_workers: int,
+        files_of_interest: Optional[Set[str]] = None,
     ) -> bool:
         def __verify_file_or_link(
             target_base_folder: Path,
@@ -3609,6 +3760,8 @@ class Dataset:
             futures_ = []
             with ThreadPoolExecutor(max_workers=max_workers) as tp:
                 for f in self._dataset_file_entries.values():
+                    if files_of_interest and f.relative_path not in files_of_interest:
+                        continue
                     future = tp.submit(
                         __verify_file_or_link,
                         target_base_folder,
@@ -3619,6 +3772,8 @@ class Dataset:
                     futures_.append(future)
 
                 for f in self._dataset_link_entries.values():
+                    if files_of_interest and f.relative_path not in files_of_interest:
+                        continue
                     # don't check whether link is in dataset part, hence None for part and chunk_selection
                     future = tp.submit(__verify_file_or_link, target_base_folder, f, None, None)
                     futures_.append(future)
@@ -3645,6 +3800,7 @@ class Dataset:
         dataset_path: Optional[str] = None,
         recursive: bool = True,
         verbose: bool = False,
+        read_hash: bool = False,
     ) -> Tuple[int, int]:
         """
         Auxiliary function for `add_external_files`
@@ -3660,6 +3816,7 @@ class Dataset:
             'image.jpg' will be downloaded to 's3_files/image.jpg' (relative path to the dataset)
         :param recursive: If True match all wildcard files recursively
         :param verbose: If True print to console files added/modified
+        :param read_hash: If True, read SHA-256 from object metadata for hash-based change detection
         :return: Number of file links added and modified
         """
         if dataset_path:
@@ -3670,11 +3827,11 @@ class Dataset:
             if StorageManager.exists_file(source_url):
                 # handle local path provided without scheme
                 source_url = StorageHelper.sanitize_url(source_url)
-                remote_objects = [StorageManager.get_metadata(source_url, return_full_path=True)]
+                remote_objects = [StorageManager.get_metadata(source_url, return_full_path=True, read_hash=read_hash)]
             elif not source_url.startswith(("http://", "https://")):
                 if source_url[-1] != "/":
                     source_url = source_url + "/"
-                remote_objects = StorageManager.list(source_url, with_metadata=True, return_full_path=True)
+                remote_objects = StorageManager.list(source_url, with_metadata=True, return_full_path=True, read_hash=read_hash)
         except Exception:
             pass
         if not remote_objects:
@@ -3692,8 +3849,10 @@ class Dataset:
             try:
                 relative_path = Path(os.path.join(dataset_path or ".", relative_path)).as_posix()
                 size = remote_object.get("size")
+                hash_val = remote_object.get("hash")
                 already_added_file = self._dataset_file_entries.get(relative_path)
-                if relative_path not in self._dataset_link_entries:
+                existing_link = self._dataset_link_entries.get(relative_path)
+                if existing_link is None:
                     if verbose:
                         self._task.get_logger().report_text(
                             "External file {} added".format(link),
@@ -3704,9 +3863,12 @@ class Dataset:
                         relative_path=relative_path,
                         parent_dataset_id=self._id,
                         size=size,
+                        hash=hash_val,
                     )
                     num_added += 1
-                elif already_added_file and already_added_file.size != size:
+                elif already_added_file and (
+                    existing_link.hash != hash_val if (hash_val and existing_link.hash) else existing_link.size != size
+                ):
                     if verbose:
                         self._task.get_logger().report_text(
                             "External file {} modified".format(link),
@@ -3718,11 +3880,11 @@ class Dataset:
                         relative_path=relative_path,
                         parent_dataset_id=self._id,
                         size=size,
+                        hash=hash_val,
                     )
                     num_modified += 1
-                elif (
-                    relative_path in self._dataset_link_entries
-                    and self._dataset_link_entries[relative_path].size != size
+                elif (hash_val and existing_link.hash and existing_link.hash != hash_val) or (
+                    not (hash_val and existing_link.hash) and existing_link.size != size
                 ):
                     if verbose:
                         self._task.get_logger().report_text(
@@ -3734,6 +3896,7 @@ class Dataset:
                         relative_path=relative_path,
                         parent_dataset_id=self._id,
                         size=size,
+                        hash=hash_val,
                     )
                     num_modified += 1
                 else:

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -80,6 +80,7 @@ from ..errors import UsageError
 from ..utilities.process.mp import ForkSafeRLock, SafeEvent
 
 from ..storage.util import get_config_object_matcher
+from ..storage.hashing import sha256sum
 from ..utilities.config import get_percentage, get_human_size_default
 from ..backend_config.environment import EnvEntry
 
@@ -628,6 +629,7 @@ class _Boto3Driver(_Driver):
     class ListResult:
         name = attrib(default=None)
         size = attrib(default=None)
+        metadata = attrib(default=None)
 
     def __init__(self) -> None:
         pass
@@ -762,6 +764,8 @@ class _Boto3Driver(_Driver):
         extra_args = {}
         try:
             extra_args = {"ContentType": get_file_mimetype(object_name or file_path)}
+            if extra and extra.get("upload_hash"):
+                extra_args["Metadata"] = {"sha256": extra["upload_hash"]}
             extra_args.update(container.config.extra_args or {})
             container.bucket.upload_file(
                 file_path,
@@ -812,12 +816,19 @@ class _Boto3Driver(_Driver):
         ex_prefix: Optional[str] = None,
         **kwargs: Any,
     ) -> Generator[ListResult, None, None]:
+        read_hash = kwargs.get("read_hash", False)
         if ex_prefix:
             res = container.bucket.objects.filter(Prefix=ex_prefix)
         else:
             res = container.bucket.objects.all()
         for res in res:
-            yield self.ListResult(name=res.key, size=res.size)
+            obj_metadata = None
+            if read_hash:
+                try:
+                    obj_metadata = container.resource.Object(container.bucket.name, res.key).metadata
+                except Exception:
+                    pass
+            yield self.ListResult(name=res.key, size=res.size, metadata=obj_metadata)
 
     def delete_object(self, object: Any, **kwargs: Any) -> bool:
         from botocore.exceptions import ClientError
@@ -1147,6 +1158,8 @@ class _GoogleCloudStorageDriver(_Driver):
     ) -> bool:
         try:
             blob = container.bucket.blob(object_name)
+            if extra and extra.get("upload_hash"):
+                blob.metadata = {"sha256": extra["upload_hash"]}
             blob.upload_from_filename(file_path)
         except Exception as ex:
             logger = self.get_logger()
@@ -1280,6 +1293,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
                 self.__legacy = False
             except ImportError:
                 try:
+                    # TODO: 'BlockBlobService' not available in Python 3.6+, marked as dead code.  
                     from azure.storage.blob import BlockBlobService  # noqa
                     from azure.common import AzureHttpError  # noqa
 
@@ -1330,6 +1344,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
             max_connections: Optional[int] = None,
             progress_callback: Optional[Callable] = None,
             content_settings: Optional["ContentSettings"] = None,
+            metadata: Optional[Dict[str,str]] = None,
         ) -> None:
             if self.__legacy:
                 self.__blob_service.create_blob_from_bytes(
@@ -1345,6 +1360,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
                     data,
                     overwrite=True,
                     content_settings=content_settings,
+                    **({"metadata": metadata} if metadata else {}),
                     **self._get_max_connections_dict(max_connections, key="max_concurrency"),
                 )
 
@@ -1356,6 +1372,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
             max_connections: Optional[int] = None,
             content_settings: Optional["ContentSettings"] = None,
             progress_callback: Optional[Callable[[int, int], None]] = None,
+            metadata: Optional[Dict[str,str]] = None,
         ) -> None:
             if self.__legacy:
                 self.__blob_service.create_blob_from_path(
@@ -1369,12 +1386,13 @@ class _AzureBlobServiceStorageDriver(_Driver):
             else:
                 with open(path, "rb") as f:
                     self.create_blob_from_data(
-                        container_name,
-                        None,
-                        blob_name,
-                        f,
+                        container_name=container_name,
+                        object_name=None,
+                        blob_name=blob_name,
+                        data=f,
                         content_settings=content_settings,
                         max_connections=max_connections,
+                        metadata=metadata,
                     )
 
         def delete_blob(self, container_name: str, blob_name: str) -> None:
@@ -1394,12 +1412,23 @@ class _AzureBlobServiceStorageDriver(_Driver):
                 client = self.__blob_service.get_blob_client(container_name, blob_name)
                 return client.exists()
 
-        def list_blobs(self, container_name: str, prefix: Optional[str] = None) -> Any:
+        def list_blobs(
+            self,
+            container_name: str,
+            prefix: Optional[str] = None,
+            include: Optional[List[str]] = None,
+        ) -> Any:
             if self.__legacy:
-                return self.__blob_service.list_blobs(container_name=container_name, prefix=prefix)
+                return self.__blob_service.list_blobs(
+                    container_name=container_name,
+                    prefix=prefix,
+                )
             else:
                 client = self.__blob_service.get_container_client(container_name)
-                return client.list_blobs(name_starts_with=prefix)
+                return client.list_blobs(
+                    name_starts_with=prefix,
+                    **({"include": include} if include else {}),
+                )
 
         def get_blob_properties(self, container_name: str, blob_name: str) -> Any:
             if self.__legacy:
@@ -1480,7 +1509,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
         container: Any,
         object_name: str,
         callback: Any = None,
-        extra: dict = None,
+        extra: Optional[Dict[str, str]] = None,
         max_connections: int = None,
         **kwargs: Any,
     ) -> bool:
@@ -1493,6 +1522,8 @@ class _AzureBlobServiceStorageDriver(_Driver):
 
         logger = self.get_logger()
         blob_name = self._blob_name_from_object_path(object_name, container.name)  # noqa: F841
+        sha256 = extra.get("upload_hash") if extra else None
+        metadata = {"sha256": sha256} if sha256 else None
         try:
             container.create_blob_from_data(
                 container.name,
@@ -1501,6 +1532,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
                 iterator.read() if hasattr(iterator, "read") else bytes(iterator),
                 max_connections=max_connections,
                 progress_callback=callback,
+                metadata=metadata,
             )
             return True
         except AzureHttpError as ex:
@@ -1534,16 +1566,19 @@ class _AzureBlobServiceStorageDriver(_Driver):
 
         logger = self.get_logger()
         blob_name = self._blob_name_from_object_path(object_name, container.name)
+        sha256 = extra.get("upload_hash") if extra else None
+        metadata = {"sha256": sha256} if sha256 else None
         try:
             from azure.storage.blob import ContentSettings  # noqa
 
             container.create_blob_from_path(
-                container.name,
-                blob_name,
-                file_path,
+                container_name=container.name,
+                blob_name=blob_name,
+                path=file_path,
                 max_connections=max_connections,
                 content_settings=ContentSettings(content_type=get_file_mimetype(object_name or file_path)),
                 progress_callback=callback,
+                metadata=metadata,
             )
             return True
         except AzureHttpError as ex:
@@ -1561,9 +1596,14 @@ class _AzureBlobServiceStorageDriver(_Driver):
         self,
         container: Any,
         ex_prefix: Optional[str] = None,
-        **kwargs: Any,
+        read_hash: Optional[bool] = False,
+        **_: Any,
     ) -> List[Any]:
-        return list(container.list_blobs(container_name=container.name, prefix=ex_prefix))
+        return list(container.list_blobs(
+            container_name=container.name,
+            prefix=ex_prefix,
+            include=["metadata"] if read_hash else None,
+        ))
 
     def delete_object(self, object: Any, **kwargs: Any) -> bool:
         container = object.container
@@ -2861,12 +2901,15 @@ class _StorageHelper:
                 self.log.warning("Failed getting object size: {}('{}')".format(e.__class__.__name__, str(e)))
         return size
 
-    def get_object_metadata(self, obj: Any) -> dict:
+    def get_object_metadata(self, obj: Any, read_hash: bool = False) -> dict:
         """
         Get the metadata of the remote object.
         The metadata is a dict containing the following keys: `name`, `size`.
+        If `read_hash` is True and the object has a SHA-256 stored in its custom metadata,
+        a ``hash`` key is also included.
 
         :param object obj: The remote object
+        :param bool read_hash: If True, attempt to read SHA-256 from the object's custom metadata.
 
         :return: A dict containing the metadata of the remote object
         """
@@ -2875,6 +2918,17 @@ class _StorageHelper:
             "size": self._get_object_size_bytes(obj),
             "name": next(filter(None, (getattr(obj, f, None) for f in name_fields)), None),
         }
+        if read_hash:
+            blob_meta = getattr(obj, "metadata", None)
+            if blob_meta is None and hasattr(obj, "reload"):
+                try:
+                    obj.reload()
+                    blob_meta = getattr(obj, "metadata", None)
+                except Exception:
+                    pass
+            sha256 = (blob_meta or {}).get("sha256")
+            if sha256:
+                metadata["hash"] = sha256
         return metadata
 
     def verify_upload(
@@ -3031,7 +3085,12 @@ class _StorageHelper:
                 result_path = quote_url(result_path, _StorageHelper._quotable_uri_schemes)
             return result_path
 
-    def list(self, prefix: Optional[str] = None, with_metadata: bool = False) -> List[Union[str, Dict[str, Any]]]:
+    def list(
+        self,
+        prefix: Optional[str] = None,
+        with_metadata: bool = False,
+        read_hash: bool = False,
+    ) -> List[Union[str, Dict[str, Any]]]:
         """
         List entries in the helper base path.
 
@@ -3051,6 +3110,9 @@ class _StorageHelper:
             containing the name and metadata of the remote file. Thus, each dictionary will contain the following
             keys: `name`, `size`.
 
+        :param read_hash: If True and `with_metadata` is True, include SHA-256 hash in each metadata dict
+            (under the ``hash`` key) when the object has it stored in its custom metadata.
+
         :return: The paths of all the objects in the storage base path under prefix or
             a list of dictionaries containing the objects' metadata.
             Listed relative to the base path.
@@ -3065,8 +3127,15 @@ class _StorageHelper:
                 prefix = prefix.rstrip("/")
                 if prefix.startswith(str(self._driver.base_path)):
                     prefix = prefix[len(str(self._driver.base_path)) :]
-            res = self._driver.list_container_objects(self._container, ex_prefix=prefix)
-            result = [obj.name if not with_metadata else self.get_object_metadata(obj) for obj in res]
+            res = self._driver.list_container_objects(
+                self._container,
+                ex_prefix=prefix,
+                read_hash=read_hash,
+            )
+            result = [
+                obj.name if not with_metadata else self.get_object_metadata(obj, read_hash=read_hash)
+                for obj in res
+            ]
 
             if self._base_url == "file://":
                 if not with_metadata:
@@ -3077,8 +3146,8 @@ class _StorageHelper:
             return result
         else:
             return [
-                obj.name if not with_metadata else self.get_object_metadata(obj)
-                for obj in self._driver.list_container_objects(self._container)
+                obj.name if not with_metadata else self.get_object_metadata(obj, read_hash=read_hash)
+                for obj in self._driver.list_container_objects(self._container, read_hash=read_hash)
             ]
 
     def download_to_file(
@@ -3464,6 +3533,8 @@ class _StorageHelper:
             object_name = self._normalize_object_name(dest_path)
             extra = extra.copy() if extra else {}
             extra.update(self._extra)
+            if "upload_hash" in extra and extra["upload_hash"] is None:
+                extra["upload_hash"], _ = sha256sum(local_path)
             cb = UploadProgressReport.from_file(local_path, self._verbose, self._log)
             res = self._driver.upload_object(
                 file_path=local_path,
@@ -3481,7 +3552,7 @@ class _StorageHelper:
         src_path: str,
         dest_path: str,
         canonized_dest_path: str,
-        extra: Optional[dict] = None,
+        extra: Optional[Dict[str, str]] = None,
         cb: Optional[Callable] = None,
         verbose: bool = False,
         retries: int = 1,
@@ -3511,7 +3582,11 @@ class _StorageHelper:
         last_ex = None
         for _i in range(max(1, int(retries))):
             try:
-                if not self._upload_from_file(local_path=src_path, dest_path=canonized_dest_path, extra=extra):
+                if not self._upload_from_file(
+                    local_path=src_path,
+                    dest_path=canonized_dest_path,
+                    extra=extra,
+                ):
                     # retry if failed
                     last_ex = ValueError("Upload failed")
                     continue

--- a/clearml/storage/manager.py
+++ b/clearml/storage/manager.py
@@ -493,6 +493,7 @@ class StorageManager:
         remote_url: str,
         return_full_path: bool = False,
         with_metadata: bool = False,
+        read_hash: bool = False,
     ) -> Optional[List[Union[str, dict]]]:
         """
         Return a list of object names inside the base path or dictionaries containing the corresponding
@@ -509,13 +510,15 @@ class StorageManager:
             containing the name and metadata of the remote file. Thus, each dictionary will contain the following
             keys: `name`, `size`.
             `return_full_path` will modify the name of each dictionary entry to the full path.
+        :param bool read_hash: If True and `with_metadata` is True, include SHA-256 hash in each metadata dict
+            when the object has it stored in its custom metadata.
 
         :return: The paths of all the objects the storage base path under prefix or the dictionaries containing the objects' metadata, relative to the base path.
             None in case of list operation is not supported (http and https protocols for example)
         """
         helper = cls.storage_helper.get(remote_url)
         try:
-            helper_list_result = helper.list(prefix=remote_url, with_metadata=with_metadata)
+            helper_list_result = helper.list(prefix=remote_url, with_metadata=with_metadata, read_hash=read_hash)
         except Exception as ex:
             LoggerRoot.get_base_logger().warning(f"Can not list files for '{remote_url}' - {ex}")
             return None
@@ -534,7 +537,12 @@ class StorageManager:
             return helper_list_result
 
     @classmethod
-    def get_metadata(cls, remote_url: str, return_full_path: bool = False) -> Optional[dict]:
+    def get_metadata(
+        cls,
+        remote_url: str,
+        return_full_path: bool = False,
+        read_hash: bool = False,
+    ) -> Optional[dict]:
         """
         Get the metadata of the remote object.
         The metadata is a dict containing the following keys: `name`, `size`.
@@ -543,6 +551,8 @@ class StorageManager:
             be created under the target local_folder. Supports S3/GS/Azure, shared filesystem and http(s).
             Example: 's3://bucket/data/'
         :param return_full_path: True for returning a full path (with the base url)
+        :param bool read_hash: If True, include SHA-256 hash in the returned dict when the object
+            has it stored in its custom metadata.
 
         :return: A dict containing the metadata of the remote object. In case of an error, `None` is returned
         """
@@ -550,7 +560,7 @@ class StorageManager:
         obj = helper.get_object(remote_url)
         if not obj:
             return None
-        metadata = helper.get_object_metadata(obj)
+        metadata = helper.get_object_metadata(obj, read_hash=read_hash)
         base_url = helper._resolve_base_url(remote_url)
         if return_full_path and not metadata["name"].startswith(base_url):
             metadata["name"] = base_url + ("/" if not base_url.endswith("/") else "") + metadata["name"]


### PR DESCRIPTION
## Related Issue \ discussion
See [this PR](https://github.com/clearml/clearml/pull/1590) for the original implementation attempt.

## Patch Description
#### SHA-256 hash comparison for external link change detection
- `LinkEntry` gains a `hash` field and persists it through `as_dict()` serialization
- `add_external_files` gets a `read_hash` flag; when set, SHA-256 is read from each object's custom cloud metadata and stored on the `LinkEntry`
- Change detection now prefers hash comparison over size when both sides carry a hash, falling back to size when hash is unavailable
- `StorageHelper.get_object_metadata` reads SHA-256 from custom blob metadata (`"sha256"` key); if missing, attempts `reload()` on the object
- `StorageHelper.list` and `StorageManager.list` / `get_metadata` thread `read_hash` through to the driver layer
- GCS and Azure upload paths store the SHA-256 in object custom metadata when `upload_hash` is present in extra; S3 stores it under `Metadata["sha256"]`
- S3 `list_container_objects` now gates the per-object HEAD call behind `read_hash` to avoid N+1 requests when hash is not needed

#### Subset file pulling in get_local_copy
- `get_local_copy` gains a `files` parameter accepting a list of relative paths; when set, only those files are downloaded
- Cache folder is suffixed with an 8-char SHA-256 hash of the sorted file list, keeping subset caches independent from each other and from the full-dataset cache
- New `_build_subset_chunk_selection` walks the full dependency graph and maps requested files to the chunk indices that contain them
- `files_of_interest` is threaded through `_merge_datasets`, `_extract_parent_datasets`, and `_verify_dataset_folder` to filter file entries, link entries, and copy operations
- For link-only datasets where no chunk-backed files match, falls back to full dependency resolution so link entries are still downloaded
- Default behaviour (`files=None`) is unchanged

#### Prune stale link entries in `sync_folder`; `upload_as_external_links` flag
`sync_folder`
- The same local-existence filter already applied to `_dataset_file_entries` is now also applied to `_dataset_link_entries`; stale external-link records are removed when their local counterpart is absent
- Combined removed count (files + links) is passed to `update_changed_files` in a single call
`upload(upload_as_external_links=True)`
- New flag uploads each local file entry directly to `<output_url>/external_links/<dataset_id>/<relative_path>` via `StorageHelper` using a thread pool (respects `max_workers` and cloud-vs-local heuristic)
- After upload, `_dataset_file_entries` is cleared and `add_external_files` registers all uploaded objects as `LinkEntry` records
- The file's pre-computed SHA-256 is forwarded to `helper.upload` via `extra={"hash": ...}` for backends that store it as object metadata
- The existing zip/chunk path then runs on the now-empty file entries (no-op) and serializes normally

## Testing
We integrated the tests from [the original PR](https://github.com/clearml/clearml/pull/1590) in our internal testing processes.