### PR TITLE
Align dependencies with release

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,14 @@
 [flake8]
-max-line-length=120
-statistics
-extend-ignore=E501
+max-line-length = 120
+statistics = True
+show-source = True
+extend-ignore = B, E203, E501, W605
+exclude = 
+    clearml/utilities/gpu/pynvml.py,
+    clearml/utilities/gpu/pyrsmi.py,
+    clearml/utilities/lowlevel/astor_unparse.py,
+    clearml/utilities/pigar,
+    clearml/utilities/plotlympl,
+    clearml/utilities/pyhocon,
+    clearml/utilities/requests_toolbelt,
+    clearml/backend_api/services

--- a/lint-requirements.txt
+++ b/lint-requirements.txt
@@ -1,0 +1,2 @@
+flake8-bugbear~=25.11.29
+flake8~=7.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,17 @@
 attrs>=18.0
 furl>=2.0.0
 jsonschema>=2.6.0
-numpy>=1.10
+numpy>=1.19.5,<1.20 ; python_version < '3.7'
+numpy>=1.21.6,<1.22 ; python_version >= '3.7' and python_version < '3.8'
+numpy>=1.24.4,<1.25 ; python_version >= '3.8' and python_version < '3.9'
+numpy>=1.26.4 ; python_version >= '3.9'
 pathlib2>=2.3.0
 Pillow>=7.0.0 ; python_version < '3.8'
 Pillow>=10.3.0 ; python_version >= '3.8'
 psutil>=3.4.2
 pyparsing>=2.0.3
 python-dateutil>=2.6.1
-pyjwt>=2.4.0,<2.11.0
+pyjwt>=2.4.0,<3.0.0
 PyYAML>=3.12
 referencing<0.40 ; python_version >= '3.8'
 requests>=2.20.0 ; python_version < '3.8'


### PR DESCRIPTION
## Patch Description
A user warned us that the dependencies listed in GitHub were not in sync with the `.whl`. This PR updates dependencies listed in GitHub with the ones we use to publish. Those were out-of-date since `clearml==2.1.4`. We apologize for the inconvenience.

P.S. This does not affect the `.whl` files since `clearml==2.1.4`, only what is displayed here. The published `clearml` package is generated by our internal processes.
