### PR TITLE
feat: set user_agent_extra default and add B2 config example

### DIFF
--- a/clearml/config/default/sdk.conf
+++ b/clearml/config/default/sdk.conf
@@ -145,6 +145,18 @@
                 #     secret: "12345678"
                 #     multipart: false
                 #     secure: false
+                # },
+                # {
+                #     # Backblaze B2 (S3-compatible). Use the regional endpoint shown in the B2 console
+                #     # and a B2 application key as the key/secret pair.
+                #     # Credentials are matched by host, so reference objects with the same host for
+                #     # these keys to apply, e.g. output_uri: "s3://s3.us-west-001.backblazeb2.com/<bucket>/<path>".
+                #     # A plain "s3://<bucket>/<path>" URL will not match this entry.
+                #     host: "s3.us-west-001.backblazeb2.com"
+                #     key: "<b2-application-key-id>"
+                #     secret: "<b2-application-key>"
+                #     multipart: true
+                #     secure: true
                 # }
             ]
         }

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -55,6 +55,7 @@ from queue import Queue, Empty
 from urllib.parse import urlparse, quote
 from os.path import expandvars, expanduser
 from heapq import heapify, heappush, heappop
+from functools import lru_cache
 from psutil import disk_usage
 
 from clearml.utilities.requests_toolbelt import (
@@ -90,6 +91,25 @@ class StorageError(Exception):
 
 class DownloadError(Exception):
     pass
+
+
+@lru_cache(maxsize=1)
+def _get_user_agent_extra() -> str:
+    from clearml.version import __version__
+
+    return "clearml/{}".format(__version__ or "dev")
+
+
+@lru_cache(maxsize=1)
+def _botocore_supports_user_agent_extra() -> bool:
+    # Probe once whether this botocore's Config accepts user_agent_extra.
+    import botocore.client
+
+    try:
+        botocore.client.Config(user_agent_extra="")
+        return True
+    except TypeError:
+        return False
 
 
 class _Driver(ABC):
@@ -653,21 +673,24 @@ class _Boto3Driver(_Driver):
             verify = None
         elif isinstance(verify, str) and not os.path.exists(verify) and verify.split("://")[0] in driver_schemes:
             verify = _Boto3Driver.download_cert(verify)
+        config_kwargs = {
+            "max_pool_connections": max(
+                int(_Boto3Driver._min_pool_connections),
+                int(_Boto3Driver._pool_connections),
+            ),
+            "connect_timeout": int(_Boto3Driver._connect_timeout),
+            "read_timeout": int(_Boto3Driver._read_timeout),
+            "signature_version": _Boto3Driver._signature_version,
+            "s3": _Boto3Driver._s3,
+        }
+        if _botocore_supports_user_agent_extra():
+            config_kwargs["user_agent_extra"] = _get_user_agent_extra()
         boto_kwargs = {
             "endpoint_url": endpoint,
             "use_ssl": cfg.secure,
             "verify": verify,
             "region_name": cfg.region or None,  # None in case cfg.region is an empty string
-            "config": botocore.client.Config(
-                max_pool_connections=max(
-                    int(_Boto3Driver._min_pool_connections),
-                    int(_Boto3Driver._pool_connections),
-                ),
-                connect_timeout=int(_Boto3Driver._connect_timeout),
-                read_timeout=int(_Boto3Driver._read_timeout),
-                signature_version=_Boto3Driver._signature_version,
-                s3=_Boto3Driver._s3,
-            ),
+            "config": botocore.client.Config(**config_kwargs),
         }
         if not cfg.use_credentials_chain:
             boto_kwargs["aws_access_key_id"] = cfg.key or None

--- a/docs/clearml.conf
+++ b/docs/clearml.conf
@@ -161,6 +161,18 @@ sdk {
                 #     secret: "12345678"
                 #     multipart: false
                 #     secure: false
+                # },
+                # {
+                #     # Backblaze B2 (S3-compatible). Use the regional endpoint shown in the B2 console
+                #     # and a B2 application key as the key/secret pair.
+                #     # Credentials are matched by host, so reference objects with the same host for
+                #     # these keys to apply, e.g. output_uri: "s3://s3.us-west-001.backblazeb2.com/<bucket>/<path>".
+                #     # A plain "s3://<bucket>/<path>" URL will not match this entry.
+                #     host: "s3.us-west-001.backblazeb2.com"
+                #     key: "<b2-application-key-id>"
+                #     secret: "<b2-application-key>"
+                #     multipart: true
+                #     secure: true
                 # }
             ]
         }


### PR DESCRIPTION
## Related Issue \ discussion

Docs counterpart: clearml/clearml-docs#1369 (adds a `##### Backblaze B2 with S3` subsection under **Non-AWS Endpoints**). The two PRs are designed to land together but neither depends on the other.

## Patch Description

Two related changes:

1. **`clearml/storage/helper.py`**: set `user_agent_extra = "clearml/<version>"` on the `botocore.client.Config` constructed in `_get_boto_resource_kwargs_from_config`. ClearML S3 traffic is currently indistinguishable from any other Python boto3 caller on S3 server-side request logs (AWS S3, Backblaze B2, MinIO, etc.); this fixes that. Version is resolved at import time via `clearml.version.__version__`; falls back to `"clearml/dev"` if empty.

2. **`clearml/config/default/sdk.conf` + `docs/clearml.conf`**: add a commented Backblaze B2 example in `sdk.aws.s3.credentials`, mirroring the existing MinIO / Dell PowerScale comment blocks so users discover the supported B2 endpoint shape inline.

## Testing Instructions

Both `.conf` files parse cleanly (verified via `pyhocon`). For the `helper.py` change, the resulting boto3 Config can be inspected directly:

```python
from clearml.storage.helper import _Boto3Driver
from clearml.backend_config.bucket_config import S3BucketConfig

cfg = S3BucketConfig(key="x", secret="x", region="us-east-1",
                     host="", secure=True, multipart=True, verify=True,
                     use_credentials_chain=False)
print(_Boto3Driver._get_boto_resource_kwargs_from_config(cfg)["config"].user_agent_extra)
# clearml/2.1.6rc0
```

`flake8 --max-line-length=120 --extend-ignore=E501 clearml/storage/helper.py` goes from 6 to 6 warnings (all pre-existing E203 on unrelated lines, none introduced by this patch).

## Other Information

No public API changes. The UA default is purely additive: appends `clearml/<version>` alongside the default `Boto3/X botocore/X` product tokens on the wire UA. The new `.conf` comments are opt-in (commented out, no default behavior change).