### PR TITLE
feat: add support for DefaultAzureCredential

### DIFF
--- a/clearml/backend_config/bucket_config.py
+++ b/clearml/backend_config/bucket_config.py
@@ -9,6 +9,8 @@ from typing import Tuple, Dict, List, Union, Optional, Any
 import furl
 from attr import attrib, attrs
 
+from .converters import strtobool
+
 
 def _none_to_empty_string(maybe_string: str) -> str:
     """Returns an empty string for any falsy value"""
@@ -379,8 +381,9 @@ class GSBucketConfigurations(BaseBucketConfigurations):
 @attrs
 class AzureContainerConfig:
     account_name = attrib(type=str)
-    account_key = attrib(type=str)
+    account_key = attrib(type=str, default=None)
     container_name = attrib(type=str, default=None)
+    use_default_credential = attrib(type=bool, default=False)
 
     def update(self, **kwargs: Any) -> None:
         for item in kwargs:
@@ -399,21 +402,33 @@ class AzureContainerConfigurations:
         container_configs: List[AzureContainerConfig] = None,
         default_account: str = None,
         default_key: str = None,
+        default_use_default_credential: bool = False,
     ) -> None:
         super(AzureContainerConfigurations, self).__init__()
         self._container_configs = container_configs or []
         self._default_account = default_account
         self._default_key = default_key
+        self._default_use_default_credential = default_use_default_credential
 
     @classmethod
     def from_config(cls, configuration: dict) -> "AzureContainerConfigurations":
         default_account = getenv("AZURE_STORAGE_ACCOUNT")
         default_key = getenv("AZURE_STORAGE_KEY")
+        try:
+            default_use_default_credential = bool(
+                strtobool(getenv("CLEARML_AZURE_STORAGE_USE_DEFAULT_CREDENTIAL", "").strip())
+            )
+        except ValueError:
+            default_use_default_credential = False
 
         default_container_configs = []
-        if default_account and default_key:
+        if default_account and (default_key or default_use_default_credential):
             default_container_configs.append(
-                AzureContainerConfig(account_name=default_account, account_key=default_key)
+                AzureContainerConfig(
+                    account_name=default_account,
+                    account_key=default_key,
+                    use_default_credential=default_use_default_credential,
+                )
             )
 
         if configuration is None:
@@ -421,12 +436,18 @@ class AzureContainerConfigurations:
                 default_container_configs,
                 default_account=default_account,
                 default_key=default_key,
+                default_use_default_credential=default_use_default_credential,
             )
 
         containers = configuration.get("containers", list())
         container_configs = [AzureContainerConfig(**entry) for entry in containers] + default_container_configs
 
-        return cls(container_configs, default_account=default_account, default_key=default_key)
+        return cls(
+            container_configs,
+            default_account=default_account,
+            default_key=default_key,
+            default_use_default_credential=default_use_default_credential,
+        )
 
     def get_config_by_uri(self, uri: str) -> AzureContainerConfig:
         """
@@ -467,6 +488,7 @@ class AzureContainerConfigurations:
         bucket_config.update(
             account_name=bucket_config.account_name or self._default_account,
             account_key=bucket_config.account_key or self._default_key,
+            use_default_credential=bucket_config.use_default_credential or self._default_use_default_credential,
         )
 
     def add_config(self, bucket_config: AzureContainerConfig) -> None:

--- a/clearml/backend_interface/setupuploadmixin.py
+++ b/clearml/backend_interface/setupuploadmixin.py
@@ -141,20 +141,30 @@ class SetupUploadMixin:
     def setup_azure_upload(
         self,
         account_name: str,
-        account_key: str,
+        account_key: Optional[str] = None,
         container_name: Optional[str] = None,
+        use_default_credential: bool = False,
     ) -> None:
         """
         Setup Azure upload options.
 
         :param account_name: Name of the account
-        :param account_key: Secret key used to authenticate the account
+        :param account_key: Secret key used to authenticate the account. Not required when
+            ``use_default_credential`` is True.
         :param container_name: The name of the blob container to upload to
+        :param use_default_credential: If True, authenticate using
+            ``azure.identity.DefaultAzureCredential`` (e.g. managed identity, environment, CLI,
+            etc.) instead of an account key. Requires the ``azure-identity`` package.
         """
+        if not account_key and not use_default_credential:
+            raise ValueError(
+                "setup_azure_upload requires either 'account_key' or 'use_default_credential=True'"
+            )
         self._bucket_config = AzureContainerConfig(  # noqa
             account_name=account_name,
             account_key=account_key,
             container_name=container_name,
+            use_default_credential=use_default_credential,
         )
         StorageHelper.add_azure_configuration(self._bucket_config, log=self.log)
         self.storage_uri = StorageHelper.get_azure_storage_uri_from_config(self._bucket_config)

--- a/clearml/config/default/sdk.conf
+++ b/clearml/config/default/sdk.conf
@@ -186,6 +186,11 @@
         #         account_name: "clearml"
         #         account_key: "secret"
         #         # container_name:
+        #
+        #         # Authenticate using azure.identity.DefaultAzureCredential
+        #         # (managed identity, environment vars, Azure CLI, etc.) instead of account_key.
+        #         # Requires `pip install azure-identity`.
+        #         # use_default_credential: false
         #     }
         # ]
     }

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -52,7 +52,7 @@ from requests import codes as requests_codes
 from requests.exceptions import ConnectionError
 from io import StringIO, BytesIO, FileIO
 from queue import Queue, Empty
-from urllib.parse import urlparse, quote
+from urllib.parse import urlparse, urlunparse, quote
 from os.path import expandvars, expanduser
 from heapq import heapify, heappush, heappop
 from psutil import disk_usage
@@ -1279,7 +1279,7 @@ class _AzureBlobServiceStorageDriver(_Driver):
         def __init__(
             self,
             name: str,
-            config: AzureContainerConfigurations,
+            config: AzureContainerConfig,
             account_url: str,
         ) -> None:
             self.MAX_SINGLE_PUT_SIZE = 4 * 1024 * 1024
@@ -1306,6 +1306,11 @@ class _AzureBlobServiceStorageDriver(_Driver):
                     )
 
             if self.__legacy:
+                if self.config.use_default_credential:
+                    raise UsageError(
+                        "DefaultAzureCredential is not supported by the legacy azure.storage.blob driver. "
+                        "Please upgrade with: pip install '\"azure.storage.blob>=12.0.0\"'"
+                    )
                 self.__blob_service = BlockBlobService(
                     account_name=self.config.account_name,
                     account_key=self.config.account_key,
@@ -1313,13 +1318,25 @@ class _AzureBlobServiceStorageDriver(_Driver):
                 self.__blob_service.MAX_SINGLE_PUT_SIZE = self.MAX_SINGLE_PUT_SIZE
                 self.__blob_service.socket_timeout = self.SOCKET_TIMEOUT
             else:
-                credential = {
-                    "account_name": self.config.account_name,
-                    "account_key": self.config.account_key,
-                }
+                if self.config.use_default_credential:
+                    try:
+                        from azure.identity import DefaultAzureCredential  # noqa
+                    except ImportError:
+                        raise UsageError(
+                            "azure-identity package is required to use DefaultAzureCredential. "
+                            "Please install it using: 'pip install azure-identity'"
+                        )
+
                 self.__blob_service = BlobServiceClient(
                     account_url=account_url,
-                    credential=credential,
+                    credential=(
+                        DefaultAzureCredential()
+                        if self.config.use_default_credential
+                        else {
+                            "account_name": self.config.account_name,
+                            "account_key": self.config.account_key,
+                        }
+                    ),
                     max_single_put_size=self.MAX_SINGLE_PUT_SIZE,
                 )
 
@@ -2571,11 +2588,19 @@ class _StorageHelper:
             if self._conf is None:
                 raise StorageError(f"Missing Azure Blob Storage configuration for {url}")
 
-            if not self._conf.account_name or not self._conf.account_key:
-                raise StorageError(f"Missing account name or key for Azure Blob Storage access for {base_url}")
+            if not self._conf.account_name:
+                raise StorageError(f"Missing account name for Azure Blob Storage access for {base_url}")
+            if not self._conf.account_key and not self._conf.use_default_credential:
+                raise StorageError(
+                    f"Missing account key for Azure Blob Storage access for {base_url} "
+                    "(set 'account_key' or enable 'use_default_credential')"
+                )
 
             self._driver = _AzureBlobServiceStorageDriver()
-            self._container = self._driver.get_container(config=self._conf, account_url=parsed.netloc)
+            self._container = self._driver.get_container(
+                config=self._conf,
+                account_url=urlunparse(("https", parsed.netloc, "", "", "", "")),
+            )
 
         elif self._scheme == _Boto3Driver.scheme:
             self._conf = copy(self._s3_configurations.get_config_by_uri(url))


### PR DESCRIPTION
## Patch Description
This will allow Azure users to authenticate to their Azure storage account using the `azure.identity.DefaultAzureCredential` approach from the `azure-identity` package. 
It requires `azure-identity` to be installed to use it, and it can be activated via your `clearml.conf` file.