### PR TITLE
feat: add ability to publish a hyperdatset via single method call

### DIFF
--- a/clearml/backend_interface/datasets/hyper_dataset.py
+++ b/clearml/backend_interface/datasets/hyper_dataset.py
@@ -173,6 +173,31 @@ class HyperDatasetManagementBackend(IdObjectBase):
         return getattr(res, "response", None)
 
     @classmethod
+    def publish_version(
+        cls,
+        version_id: str,
+        force: bool = False,
+        publishing_task: Optional[str] = None,
+    ):
+        """
+        Publish a dataset version and refresh its statistics.
+
+        :param version_id: Draft version identifier
+        :param force: Force publish even with active annotation tasks
+        :param publishing_task: Annotation task identifier issuing the commit
+        :return: Backend response payload
+        """
+        return cls._send(
+            session=cls._get_default_session(),
+            req=datasets.PublishVersionRequest(
+                version=version_id,
+                force=force or None,
+                publishing_task=publishing_task,
+            ),
+            raise_on_errors=False,
+        )
+
+    @classmethod
     def get_dataset(
         cls,
         name: str,

--- a/clearml/hyperdatasets/core.py
+++ b/clearml/hyperdatasets/core.py
@@ -351,7 +351,9 @@ class HyperDataset(HyperDatasetManagement):
         # Import locally to avoid circular dependencies
         from .data_view import DataView
         data_view = DataView(
-            iteration_order="sequential", iteration_infinite=False, auto_connect_with_task=False
+            iteration_order="sequential",
+            iteration_infinite=False,
+            auto_connect_with_task=False,
         )
 
         have_hashes = False

--- a/clearml/hyperdatasets/management.py
+++ b/clearml/hyperdatasets/management.py
@@ -63,9 +63,12 @@ class HyperDatasetManagement:
                 dataset_id=dataset_id, version_name=version_name
             )
             if not resolved_version_id:
-                raise ValueError(
-                    f"{'Version not found: ' + version_name if version_name else 'No versions found'} (dataset={dataset_name or dataset_id})"  # noqa
+                error_message = (
+                    f"Version not found: {version_name}"
+                    if version_name
+                    else "No versions found"
                 )
+                raise ValueError(f"{error_message} (dataset={dataset_name or dataset_id})")
 
         target_cls = cls._result_class()
         obj = target_cls.__new__(target_cls)  # type: ignore[misc]
@@ -220,11 +223,36 @@ class HyperDatasetManagement:
         """
         if not getattr(self, "_version_id", None):
             raise ValueError("HyperDataset instance is not bound to a dataset version")
+
         return HyperDatasetManagementBackend.commit_version(
             version_id=self._version_id,
             publish=publish,
             force=force,
             calculate_stats=calculate_stats,
             override_stats=override_stats,
+            publishing_task=publishing_task,
+        )
+
+    def publish_version(
+        self,
+        *,
+        force: bool = False,
+        publishing_task: Optional[str] = None,
+    ):
+        """
+        Publish the bound HyperDataset version.
+
+        :param publish: Publish the version after committing (optional)
+        :param force: Force publish even with active annotation tasks
+        :param publishing_task: Annotation task identifier issuing the commit
+
+        :return: Backend response payload
+        """
+        if not getattr(self, "_version_id", None):
+            raise ValueError("HyperDataset instance is not bound to a dataset version")
+
+        return HyperDatasetManagementBackend.publish_version(
+            version_id=self._version_id,
+            force=force,
             publishing_task=publishing_task,
         )


### PR DESCRIPTION
## Patch Description
This implements the feature that allows transitioning a hyperdataset from the `draft` state to the `published` state.