### PR TITLE
fix: Deprecate parent_ids (but keep it usable) in favor of parent_id

### DIFF
--- a/clearml/backend_interface/datasets/hyper_dataset.py
+++ b/clearml/backend_interface/datasets/hyper_dataset.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Dict, Any, Sequence
+from typing import Optional, List, Dict, Any, Sequence, Union
 
 from ...backend_api.services import datasets
 from ...backend_api import Session
@@ -78,7 +78,8 @@ class HyperDatasetManagementBackend(IdObjectBase):
         name: str,
         dataset_id: str,
         comment: Optional[str] = None,
-        parent_ids: Optional[List[str]] = None,
+        parent_id: Optional[str] = None,
+        **kwargs,
     ):
         """
         Create a new dataset version or return the existing version with the same name.
@@ -86,7 +87,9 @@ class HyperDatasetManagementBackend(IdObjectBase):
         :param name: Human-readable name identifying the dataset version
         :param dataset_id: Identifier of the parent dataset collection
         :param comment: Optional description attached to the dataset version
-        :param parent_ids: Optional list of parent version IDs to record lineage
+        :param parent_id: Optional list of parent version IDs to record lineage
+        :param parent_ids: (Deprecated) Optional list of parent dataset version IDs to link.
+            Only one parent ID by hyperdataset is supported. Use `parent_id` instead.
 
         :return: Newly created version ID or the ID of an existing version with the same name
         """
@@ -96,7 +99,10 @@ class HyperDatasetManagementBackend(IdObjectBase):
             name=name,
             comment=comment,
             task=(current.id if current else None),
-            parent=parent_ids,
+            parent=HyperDatasetManagementBackend._define_parent_id(
+                parent_id=parent_id,
+                parent_ids=kwargs.get("parent_ids", None),
+            ),
         )
         session = cls._get_default_session()
         try:
@@ -533,6 +539,31 @@ class HyperDatasetManagementBackend(IdObjectBase):
                 page += 1
         except Exception:
             return False
+
+    @staticmethod
+    def _define_parent_id(
+        parent_id: Optional[str] = None,
+        parent_ids: Optional[Union[str, List[str]]] = None,
+    ) -> Optional[str]:
+        """
+        Allows the deprecation of the `parent_ids` argument by duplicating the attribute but only using
+        `parent_id` internally and encouraging the usage of `parent_id` against `parent_ids`.
+        We only ever planned to support one parent ID per version, `parent_ids` was a typo in that context.
+
+        :param parent_id: Optional parent dataset version IDs to link
+        :param parent_ids: (Deprecated) Optional list of parent dataset version IDs to link.
+            Only one parent ID by hyperdataset is supported. Use `parent_id` instead.
+        """
+        return (
+            parent_id
+            or (
+                parent_ids[0]
+                if isinstance(parent_ids, list) and len(parent_ids) > 0
+                else parent_ids
+                if isinstance(parent_ids, str)
+                else None
+            )
+        )
 
     @classmethod
     def update_dataset_tags(

--- a/clearml/hyperdatasets/core.py
+++ b/clearml/hyperdatasets/core.py
@@ -34,9 +34,11 @@ class HyperDataset(HyperDatasetManagement):
         dataset_name: str,
         version_name: str,
         description: Optional[str] = None,
-        parent_ids: Optional[List[str]] = None,
+        parent_id: Optional[str] = None,
+        # parent_ids: Optional[List[str]] = None,
         field_mappings: Optional[Dict[str, Any]] = None,
         raise_if_exists: bool = False,
+        **kwargs,
     ):
         """Create a new HyperDataset version within the requested project.
 
@@ -44,7 +46,9 @@ class HyperDataset(HyperDatasetManagement):
         :param dataset_name: HyperDataset collection name (top-level dataset)
         :param version_name: Version name to create (or reuse if it already exists)
         :param description: Optional dataset description string
-        :param parent_ids: Optional list of parent dataset version IDs to link
+        :param parent_id: Optional parent dataset version IDs to link
+        :param parent_ids: (Deprecated) Optional list of parent dataset version IDs to link.
+            Only one parent ID by hyperdataset is supported. Use `parent_id` instead.
         :param field_mappings: Optional mapping that defines vector-capable metadata fields.
             Provide the fully-qualified frame metadata path (e.g. ``meta.my_vector``) and
             the corresponding field settings accepted by the ClearML backend / Elasticsearch
@@ -67,8 +71,13 @@ class HyperDataset(HyperDatasetManagement):
         self._dataset_name = dataset_name
         self._version_name = version_name
         self._description = description
-        self._parent_ids = parent_ids
         self._field_mappings = field_mappings
+
+        self._parent_id = HyperDatasetManagementBackend._define_parent_id(
+            parent_id=parent_id,
+            parent_ids=kwargs.get("parent_ids", None),
+        )
+        self._parent_ids = self._parent_id
 
         try:
             self._project_id = get_or_create_project(Session(), project_name)
@@ -83,7 +92,7 @@ class HyperDataset(HyperDatasetManagement):
         self._version_id = HyperDatasetManagementBackend.create_version(
             name=version_name,
             dataset_id=self._dataset_id,
-            parent_ids=parent_ids,
+            parent_id=self._parent_id,
         )
         self._tags = None  # Create uninitialized _tags cache
 
@@ -723,7 +732,7 @@ class HyperDataset(HyperDatasetManagement):
             project_name=self._project_name,
             dataset_name=self._dataset_name,
             version_name=getattr(snapshot_response, "name", None),
-            parent_ids=self._version_id,
+            parent_id=self._version_id,
         )
 
         return snapshot_hyperdataset


### PR DESCRIPTION
## Patch Description
The `HyperDataset` class had a `parent_ids` argument which only worked when a string was passed (which represented the *single* parent ID of the hyperdataset, the only supported feature; multiple parents was never supported and won't be).

This PR is about enabling `parent_id`, removing `parent_ids` from the signature, but still allowing it to work (via `kwargs`) for backwards compatibility. The `HyperDataset` class's methods and `HyperDatasetManagementBackend` also rely on such a convention, which was also fixed by adding `parent_id` there and using `kwargs`.

The implementation behavior is otherwise unchanged.

## Testing Instructions
If your code is using the `parent_ids` argument and you see it, switch it to `parent_id` after updating your code to the latest version.