### PR TITLE
gh-1651: Use `usedforsecurity=False` everywhere where hashing is used

### DIFF
--- a/clearml/automation/job.py
+++ b/clearml/automation/job.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import os
 import subprocess
@@ -13,6 +12,7 @@ from typing import Optional, Mapping, Sequence, Callable, Union, Tuple, List, An
 
 from pathlib2 import Path
 
+from clearml.utilities.hashing import md5_safe_hash
 from ..backend_api import Session
 from ..backend_api.services import tasks as tasks_service
 from ..backend_interface.util import get_or_create_project, exact_match_regex
@@ -67,8 +67,8 @@ class BaseJob:
 
     @staticmethod
     def get_metric_req_params(title: str, series: str) -> Tuple[List[str], str, str, List[str]]:
-        title = hashlib.md5(str(title).encode("utf-8")).hexdigest()
-        series = hashlib.md5(str(series).encode("utf-8")).hexdigest()
+        title = md5_safe_hash(data=str(title).encode("utf-8")).hexdigest()
+        series = md5_safe_hash(data=str(series).encode("utf-8")).hexdigest()
         metric = f"last_metrics.{title}.{series}."
         values = ["min_value", "max_value", "value"]
         metrics = [metric + v for v in values]

--- a/clearml/automation/optimization.py
+++ b/clearml/automation/optimization.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 from copy import copy, deepcopy
 from datetime import datetime
@@ -20,6 +19,8 @@ from typing import (
     Any,
 )
 from abc import ABC, abstractmethod
+
+from clearml.utilities.hashing import md5_safe_hash
 
 from .job import ClearmlJob, LocalClearmlJob
 from .parameters import Parameter
@@ -257,8 +258,8 @@ class Objective(_ObjectiveInterface):
         if order_by and (order_by.startswith("last_metrics") or order_by.startswith("-last_metrics")):
             parts = order_by.split(".")
             if parts[-1] in ("min", "max", "last"):
-                title = hashlib.md5(str(parts[1]).encode("utf-8")).hexdigest()
-                series = hashlib.md5(str(parts[2]).encode("utf-8")).hexdigest()
+                title = md5_safe_hash(data=str(parts[1]).encode("utf-8")).hexdigest()
+                series = md5_safe_hash(data=str(parts[2]).encode("utf-8")).hexdigest()
                 minmax = "min_value" if "min" in parts[3] else ("max_value" if "max" in parts[3] else "value")
                 order_by = "{}last_metrics.".join(
                     (
@@ -281,8 +282,8 @@ class Objective(_ObjectiveInterface):
         :return: The objective title/series.
         """
         if not self._metric:
-            title = hashlib.md5(str(self.title).encode("utf-8")).hexdigest()
-            series = hashlib.md5(str(self.series).encode("utf-8")).hexdigest()
+            title = md5_safe_hash(data=str(self.title).encode("utf-8")).hexdigest()
+            series = md5_safe_hash(data=str(self.series).encode("utf-8")).hexdigest()
             self._metric = title, series
 
         sign = (
@@ -1047,8 +1048,8 @@ class SearchStrategy:
         if order_by and (order_by.startswith("last_metrics") or order_by.startswith("-last_metrics")):
             parts = order_by.split(".")
             if parts[-1] in ("min", "max", "last"):
-                title = hashlib.md5(str(parts[1]).encode("utf-8")).hexdigest()
-                series = hashlib.md5(str(parts[2]).encode("utf-8")).hexdigest()
+                title = md5_safe_hash(data=str(parts[1]).encode("utf-8")).hexdigest()
+                series = md5_safe_hash(data=str(parts[2]).encode("utf-8")).hexdigest()
                 minmax = "min_value" if "min" in parts[3] else ("max_value" if "max" in parts[3] else "value")
                 order_by = "{}last_metrics.".join(
                     (

--- a/clearml/backend_interface/metrics/events.py
+++ b/clearml/backend_interface/metrics/events.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-import hashlib
 import time
 from functools import reduce
 from logging import getLevelName
@@ -12,6 +11,8 @@ import pathlib2
 import six
 from PIL import Image
 from six.moves.urllib.parse import urlparse, urlunparse
+
+from clearml.utilities.hashing import md5_safe_hash
 
 from ...backend_api.services import events
 from ...config import deferred_config
@@ -421,11 +422,11 @@ class UploadEvent(MetricsEventAdapter):
                 return folder_path
             parts = folder_path.split(".")
             if len(parts) > 1:
-                prefix = hashlib.md5(str(".".join(parts[:-1])).encode("utf-8")).hexdigest()
+                prefix = md5_safe_hash(data=str(".".join(parts[:-1])).encode("utf-8")).hexdigest()
                 new_path = "{}.{}".format(prefix, parts[-1])
                 if len(new_path) <= 250:
                     return new_path
-            return hashlib.md5(str(folder_path).encode("utf-8")).hexdigest()
+            return md5_safe_hash(data=str(folder_path).encode("utf-8")).hexdigest()
 
         self._generate_file_name()
         e_storage_uri = self._upload_uri or storage_uri

--- a/clearml/config/__init__.py
+++ b/clearml/config/__init__.py
@@ -6,6 +6,8 @@ from os.path import expandvars, expanduser
 from typing import Optional, Callable, Iterable, Tuple, List, Any
 from pathlib2 import Path
 
+from clearml.utilities.hashing import md5_safe_hash
+
 from .defs import *  # noqa: F403
 from .remote import running_remotely_task_id as _running_remotely_task_id
 from ..backend_api import load_config
@@ -230,11 +232,10 @@ def get_node_id(default: int = 0) -> int:
                     torch_rank = int(w_id)
                 except Exception:
                     # guess a number based on wid hopefully unique value
-                    import hashlib
-
-                    h = hashlib.md5()
-                    h.update(str(w_id).encode("utf-8"))
-                    torch_rank = int(h.hexdigest(), 16)
+                    torch_rank = int(
+                        md5_safe_hash(data=str(w_id).encode("utf-8")).hexdigest(),
+                        16,
+                    )
         except Exception:
             torch_rank = None
 

--- a/clearml/datasets/dataset.py
+++ b/clearml/datasets/dataset.py
@@ -19,6 +19,8 @@ import psutil
 from attr import attrs, attrib
 from pathlib2 import Path
 
+from clearml.utilities.hashing import sha256_safe_hash
+
 from .. import Task, StorageManager, Logger
 from ..backend_api import Session
 from ..backend_interface.task.development.worker import DevWorker
@@ -2916,8 +2918,6 @@ class Dataset:
 
         :return: the target folder
         """
-        import hashlib
-
         assert part is None or (isinstance(part, int) and part >= 0)
         assert num_parts is None or (isinstance(num_parts, int) and num_parts >= 1)
 
@@ -2933,8 +2933,8 @@ class Dataset:
         subset_hash = None
         link_entries_of_interest = None
         if files_of_interest:
-            subset_hash = hashlib.sha256(
-                "\n".join(sorted(files_of_interest)).encode()
+            subset_hash = sha256_safe_hash(
+                data="\n".join(sorted(files_of_interest)).encode(),
             ).hexdigest()[:8]
             link_entries_of_interest = {
                 k: v for k, v in self._dataset_link_entries.items() if k in files_of_interest

--- a/clearml/storage/cache.py
+++ b/clearml/storage/cache.py
@@ -1,5 +1,4 @@
 import atexit
-import hashlib
 import os
 import shutil
 from collections import OrderedDict
@@ -7,6 +6,8 @@ from threading import RLock
 from typing import Union, Optional, Tuple, Dict
 
 from pathlib2 import Path
+
+from clearml.utilities.hashing import md5_safe_hash
 
 from .helper import StorageHelper
 from .url import quote_url
@@ -107,7 +108,7 @@ class CacheManager:
 
         @classmethod
         def get_hashed_url_file(cls, url: str) -> str:
-            str_hash = hashlib.md5(url.encode()).hexdigest()
+            str_hash = md5_safe_hash(data=url.encode()).hexdigest()
             filename = url.split("/")[-1]
             return f"{str_hash}.{quote_url(filename)}"
 

--- a/clearml/storage/hashing.py
+++ b/clearml/storage/hashing.py
@@ -1,13 +1,16 @@
-import hashlib
 import json
 from typing import Optional, Union, Dict, Tuple
 from zlib import crc32
 
 from clearml.debugging.log import LoggerRoot
+from clearml.utilities.hashing import (
+    safe_hash,
+    sha256_safe_hash,
+    StrHashFunction,
+)
 
 STR_HASH_FUNCTIONS = {"md5", "sha256", "sha384", "sha512"}
 DICT_HASH_FUNCTIONS = {"crc32", *STR_HASH_FUNCTIONS}
-StrHashFunction = str  # Literal["md5", "sha256", "sha384", "sha512"]
 DictHashFunction = str  # Literal["md5", "sha256", "sha384", "sha512", "crc32"]
 
 
@@ -33,27 +36,27 @@ def sha256sum(
         the header) and the hex digest of the full file. The second element
         is None if skip_header is 0. Returns (None, None) on error.
     """
-    h = hashlib.sha256()
-    file_hash = hashlib.sha256()
+    hasher = sha256_safe_hash()
+    file_hasher = sha256_safe_hash()
     b = bytearray(block_size)
     mv = memoryview(b)
     try:
         with open(filename, "rb", buffering=0) as f:
             if skip_header:
-                file_hash.update(f.read(skip_header))
+                file_hasher.update(f.read(skip_header))
             # noinspection PyUnresolvedReferences
             for n in iter(lambda: f.readinto(mv), 0):
-                h.update(mv[:n])
+                hasher.update(mv[:n])
                 if skip_header:
-                    file_hash.update(mv[:n])
+                    file_hasher.update(mv[:n])
     except Exception as e:
         LoggerRoot.get_base_logger().warning(str(e))
         return None, None
 
     return (
-        h.hexdigest(),
+        hasher.hexdigest(),
         (
-            file_hash.hexdigest()
+            file_hasher.hexdigest()
             if skip_header
             else None
         )
@@ -86,14 +89,16 @@ def hash_text(
 
     :param text: string to hash
     :param seed: use prefix seed for hashing
-    :param hash_func: hashing function. currently supported md5 sha256
+    :param hash_func: hashing function. currently supported: "md5", "sha256", "sha384", "sha512"
     :return: hashed string
     """
     if hash_func not in STR_HASH_FUNCTIONS:
         raise ValueError(f"Invalid hash function: '{hash_func}'. Valid hash_func parameters are: {STR_HASH_FUNCTIONS}")
-    h = getattr(hashlib, hash_func)()
-    h.update((str(seed) + str(text)).encode("utf-8"))
-    return h.hexdigest()
+
+    return safe_hash(
+        name=hash_func,
+        data=f"{seed}{text}".encode("utf-8"),
+    ).hexdigest()
 
 
 def md5text(

--- a/clearml/storage/helper.py
+++ b/clearml/storage/helper.py
@@ -6,7 +6,6 @@ import itertools
 import json
 import logging
 import mimetypes
-import hashlib
 import os
 import platform
 import shutil
@@ -58,6 +57,7 @@ from os.path import expandvars, expanduser
 from heapq import heapify, heappush, heappop
 from psutil import disk_usage
 
+from clearml.utilities.hashing import md5_safe_hash
 from clearml.utilities.requests_toolbelt import (
     MultipartEncoderMonitor,
     MultipartEncoder,
@@ -4111,7 +4111,7 @@ class StorageHelper(_StorageHelper):
         scheme, netloc, filename, query, fragment = fast_urlsplit(canonized_url, allow_fragments=False)
         if query:
             filename = filename.split('/')
-            filename[-1] = f'{hashlib.md5(query.encode()).hexdigest()}.{filename[-1]}'
+            filename[-1] = f'{md5_safe_hash(data=query.encode()).hexdigest()}.{filename[-1]}'
             filename = '/'.join(filename if filename[0] else filename[1:])
         else:
             filename = str(Path(filename.lstrip("/")))
@@ -4568,7 +4568,7 @@ class StorageHelper(_StorageHelper):
                 (
                     f
                     if len(f) <= 255
-                    else f"{hashlib.md5(f.encode()).hexdigest()}.{f[-200:]}"
+                    else f"{md5_safe_hash(data=f.encode()).hexdigest()}.{f[-200:]}"
                 )
                 for f in folder_path.split(sep)
             ]

--- a/clearml/utilities/hashing.py
+++ b/clearml/utilities/hashing.py
@@ -1,0 +1,114 @@
+import hashlib
+import sys
+
+StrHashFunction = str  # Literal["md5", "sha256", "sha384", "sha512"]
+
+# ``usedforsecurity`` was added to hashlib constructors in Python 3.9.
+# All hashing in this SDK is non-cryptographic
+# (caching, deduplication, identity, path shortening),
+# so we pass ``usedforsecurity=False`` where supported.
+# This lets these digests (notably md5) run on FIPS-hardened runtimes,
+# where the crypto provider otherwise refuses to instantiate them.
+IS_HASHLIB_USEDFORSECURITY_SUPPORTED = sys.version_info >= (3, 9)
+
+
+def safe_hash(
+    name: StrHashFunction,
+    data: bytes = b"",
+    *args,
+    **kwargs,
+):
+    """
+    Create a hashlib hasher object marked as non-security-related so it works in FIPS-compliant systems.
+
+    :param name: hash algorithm name (e.g. "md5", "sha256")
+    :param data: optional initial data to hash
+    :return: a hashlib hash object
+    """
+    return hashlib.new(
+        name,
+        data,
+        *args,
+        **kwargs,
+        **(
+            {"usedforsecurity": False}  # This option silences FIPS-related errors
+            if IS_HASHLIB_USEDFORSECURITY_SUPPORTED
+            else {}
+        ),
+    )
+
+
+def md5_safe_hash(
+    data: bytes = b"",
+    *args,
+    **kwargs,
+):
+    """
+    Create a hashlib.md5 hasher object marked as non-security-related so it works in FIPS-compliant systems.
+
+    :param data: optional initial data to hash
+    :return: a hashlib hash object
+    """
+    return safe_hash(
+        name="md5",
+        data=data,
+        *args,
+        **kwargs,
+    )
+
+
+def sha256_safe_hash(
+    data: bytes = b"",
+    *args,
+    **kwargs,
+):
+    """
+    Create a hashlib.sha256 hasher object marked as non-security-related so it works in FIPS-compliant systems.
+
+    :param data: optional initial data to hash
+    :return: a hashlib hash object
+    """
+    return safe_hash(
+        name="sha256",
+        data=data,
+        *args,
+        **kwargs,
+    )
+
+
+def sha384_safe_hash(
+    data: bytes = b"",
+    *args,
+    **kwargs,
+):
+    """
+    Create a hashlib.sha384 hasher object marked as non-security-related so it works in FIPS-compliant systems.
+
+    :param data: optional initial data to hash
+    :return: a hashlib hash object
+    """
+    return safe_hash(
+        name="sha384",
+        data=data,
+        *args,
+        **kwargs,
+    )
+
+
+def sha512_safe_hash(
+    data: bytes = b"",
+    *args,
+    **kwargs,
+):
+    """
+    Create a hashlib.sha512 hasher object marked as non-security-related so it works in FIPS-compliant systems.
+
+    :param data: optional initial data to hash
+    :return: a hashlib hash object
+    """
+    return safe_hash(
+        name="sha512",
+        data=data,
+        *args,
+        **kwargs,
+    )


### PR DESCRIPTION
## Related Issue \ discussion
See #1651 .

## Patch Description
We centralized usage of `hashlib` and used the `usedforsecurity=False` argument for Python 3.9+. For Python 3.8 and lower, FIPS-compliance requires not supporting the hashing algorithms since the `usedforsecurity=False` option is not implemented.

Note: Since Python 3.8 (and even 3.9) is [already in end-of-life](https://devguide.python.org/versions/), we recommend users with FIPS compliance requirements to migrate to Python 3.9+ to support `usedforsecurity=False`.