### PR TITLE
bugfix: repair syntax error and add hyperdataset visibility argument

### DIFF
--- a/clearml/backend_interface/datasets/hyper_dataset.py
+++ b/clearml/backend_interface/datasets/hyper_dataset.py
@@ -489,6 +489,7 @@ class HyperDatasetManagementBackend(IdObjectBase):
             req=datasets.GetVersionsRequest(
                 dataset=dataset_id,
                 versions=[version_id],
+                only_published=False,  # Fails to retrieve committed/drafted versions without this option
                 **({"only_fields": only_fields} if only_fields is not None else {}),
             ),
             raise_on_errors=False,

--- a/clearml/backend_interface/datasets/hyper_dataset_data_view.py
+++ b/clearml/backend_interface/datasets/hyper_dataset_data_view.py
@@ -98,11 +98,11 @@ class DataViewManagementBackend(IdObjectBase):
             req=dataviews.CreateRequest(
                 name=(
                     name
-                    or make_message('Anonymous dataview (%(user)s@%(host)s %(time)s)'),
+                    or make_message('Anonymous dataview (%(user)s@%(host)s %(time)s)')
                 ),
                 description=(
                     description
-                    or make_message('Auto-generated on %(time)s by %(user)s@%(host)s'),
+                    or make_message('Auto-generated on %(time)s by %(user)s@%(host)s')
                 ),
                 tags=tags,
                 filters=[],


### PR DESCRIPTION
## Patch Description
There was a minor issue in hyperdataset inheritance that prevented visibility of the inheritance from the SDK. This PR fixes it.

## Testing Instructions
You can use the `parent_id` argument when instantiating a hyperdataset that is meant to be the child of its parent via `HyperDataset(project_id=..., dataset_id=..., version_id=..., parent_id=<here>)`.