### PR TITLE
gh-1547: Replace .format and % calls by f-strings

### DIFF
--- a/clearml/backend_api/api_proxy.py
+++ b/clearml/backend_api/api_proxy.py
@@ -35,7 +35,7 @@ class ApiServiceProxy:
             version = [str(v) for v in ApiServiceProxy._available_versions if Session.check_min_api_version(v)][-1]
             Session.api_version = version
             self.__dict__["__wrapped_version__"] = Session.api_version
-            name = ".v{}.{}".format(version.replace(".", "_"), self.__dict__.get("__wrapped_name__"))
+            name = f".v{version.replace('.', '_')}.{self.__dict__.get('__wrapped_name__')}"
             self.__dict__["__wrapped__"] = self._import_module(name, self._main_services_module)
 
         return getattr(self.__dict__["__wrapped__"], attr)
@@ -58,7 +58,7 @@ class ExtApiServiceProxy(ApiServiceProxy):
             except ImportError:
                 pass
 
-        raise ImportError("No module '{}' in all predefined services module paths".format(name))
+        raise ImportError(f"No module '{name}' in all predefined services module paths")
 
     @classmethod
     def add_services_module(cls, module_path: str) -> None:

--- a/clearml/backend_api/schema/service.py
+++ b/clearml/backend_api/schema/service.py
@@ -56,17 +56,17 @@ class Service:
     def parse(self, service_config: ConfigTree) -> None:
         self._default = service_config.get("_default", ConfigTree()).as_plain_ordered_dict()
 
-        self._doc = "{} service".format(self.name)
+        self._doc = f"{self.name} service"
         description = service_config.get("_description", "")
         if description:
-            self._doc += "\n\n{}".format(description)
+            self._doc += f"\n\n{description}"
         self._definitions = service_config.get("_definitions", ConfigTree()).as_plain_ordered_dict()
         self._definitions_refs = {k: self._get_schema_references(v) for k, v in self._definitions.items()}
         all_refs = set(itertools.chain(*self.definitions_refs.values()))
         if not all_refs.issubset(self.definitions):
+            unresolved_references = ", ".join(all_refs.difference(self.definitions))
             raise ValueError(
-                "Unresolved references (%s) in %s/definitions"
-                % (", ".join(all_refs.difference(self.definitions)), self.name)
+                f"Unresolved references ({unresolved_references}) in {self.name}/definitions"
             )
 
         actions = {k: v.as_plain_ordered_dict() for k, v in service_config.items() if not k.startswith("_")}
@@ -85,9 +85,7 @@ class Service:
                 return float(action_version)
             except (ValueError, TypeError) as ex:
                 raise ValueError(
-                    "Failed parsing version number {} ({}) in {}/{}".format(
-                        action_version, ex.args[0], self.name, action_name
-                    )
+                    f"Failed parsing version number {action_version} ({ex.args[0]}) in {self.name}/{action_name}"
                 )
 
         def add_internal(cfg: dict) -> dict:
@@ -163,18 +161,16 @@ class Service:
                     self._resolve_schema_references(schema, refs=refs)
                     definitions_keys.update(refs)
                 except ValueError as ex:
-                    name = "%s.%s/%.1f/%s" % (
-                        self.name,
-                        action_name,
-                        action_version,
-                        schema_key,
-                    )
-                    raise ValueError("%s in %s" % (str(ex), name))
+                    raise ValueError(f"{ex} in {self.name}.{action_name}/{action_version:.1f}/{schema_key}")
 
         return Action(
             name=action_name,
             version=action_version,
             definitions_keys=list(definitions_keys),
             service=self.name,
-            **({key: value for key, value in data.items() if key in attr.fields_dict(Action)})
+            **({
+                key: value
+                for key, value in data.items()
+                if key in attr.fields_dict(Action)
+            })
         )

--- a/clearml/backend_api/session/callresult.py
+++ b/clearml/backend_api/session/callresult.py
@@ -44,7 +44,7 @@ class CallResult:
         if response and not isinstance(response, Response):
             raise ValueError("response should be an instance of %s" % Response.__name__)
         elif response_data and not isinstance(response_data, dict):
-            raise TypeError("data should be an instance of {}".format(dict.__name__))
+            raise TypeError(f"data should be an instance of {dict.__name__}")
 
         self.__meta = meta
         self.__response = response
@@ -58,7 +58,7 @@ class CallResult:
             try:
                 self.__response_data = response.to_dict()
             except AttributeError:
-                raise TypeError("response should be an instance of {}".format(Response.__name__))
+                raise TypeError(f"response should be an instance of {Response.__name__}")
         else:
             self.__response_data = None
 
@@ -115,7 +115,7 @@ class CallResult:
             # TODO: validate meta?
             # meta.validate()
         except Exception as ex:
-            raise ValueError("Failed parsing meta section in response payload (data=%s, error=%s)" % (data, ex))
+            raise ValueError(f"Failed parsing meta section in response payload (data={data}, error={ex})")
 
         response = None
         response_data = None
@@ -127,7 +127,7 @@ class CallResult:
                 # response.validate()
         except Exception as e:
             if logger:
-                logger.warning("Failed parsing response: %s" % str(e))
+                logger.warning(f"Failed parsing response: {e}")
         return cls(
             meta=meta,
             response=response,
@@ -178,10 +178,10 @@ class CallResult:
                     progress = (
                         "waiting forever"
                         if timeout is False
-                        else "%.1f/%.1f seconds remaining" % (remaining, float(timeout or 0))
+                        else f"{remaining:.1f}/{float(timeout or 0):.1f} seconds remaining"
                     )
                     session._logger.info(
-                        "Waiting for asynchronous call %s (%s)" % (self.request_cls.__name__, progress)
+                        f"Waiting for asynchronous call {self.request_cls.__name__} ({progress})"
                     )
                 time.sleep(poll_interval)
                 remaining -= poll_interval
@@ -193,4 +193,4 @@ class CallResult:
         raise TimeoutExpiredError(self._format_msg("Timeout expired"), call_id=self.meta.id)
 
     def _format_msg(self, msg: str) -> str:
-        return msg + " for call %s (%s)" % (self.request_cls.__name__, self.meta.id)
+        return f"{msg} for call {self.request_cls.__name__} ({self.meta.id})"

--- a/clearml/backend_api/session/datamodel.py
+++ b/clearml/backend_api/session/datamodel.py
@@ -106,31 +106,24 @@ class DataModel:
             )
 
     def __repr__(self) -> str:
-        return "<{}.{}: {}>".format(
-            self.__module__.split(".")[-1],
-            type(self).__name__,
-            json.dumps(
-                self.to_dict(),
-                indent=4,
-                default=format_date,
-            ),
+        payload = json.dumps(
+            self.to_dict(),
+            indent=4,
+            default=format_date,
         )
+        return f"<{self.__module__.split('.')[-1]}.{type(self).__name__}: {payload}>"
 
     @staticmethod
     def assert_isinstance(value: Any, field_name: str, expected: type, is_array: bool = False) -> None:
         if not is_array:
             if not isinstance(value, expected):
-                raise TypeError("Expected %s of type %s, got %s" % (field_name, expected, type(value).__name__))
+                raise TypeError(f"Expected {field_name} of type {expected}, got {type(value).__name__}")
             return
 
         if not all(isinstance(x, expected) for x in value):
             raise TypeError(
-                "Expected %s of type list[%s], got %s"
-                % (
-                    field_name,
-                    expected,
-                    ", ".join(set(type(x).__name__ for x in value)),
-                )
+                f"Expected {field_name} of type list[{expected}], "
+                f"got {', '.join(set(type(x).__name__ for x in value))}"
             )
 
     @staticmethod
@@ -165,8 +158,7 @@ class NonStrictDataModelMixin:
     def __init__(self, **kwargs: Any) -> None:
         # unexpected = [key for key in kwargs if not key.startswith('_')]
         # if unexpected:
-        #     message = '{}: unused keyword argument(s) {}' \
-        #         .format(type(self).__name__, unexpected)
+        #     message = f"{type(self).__name__}: unused keyword argument(s) {unexpected}"
         #     warnings.warn(message, UnusedKwargsWarning)
 
         # ignore extra data warnings

--- a/clearml/backend_api/session/jsonmodels/builders.py
+++ b/clearml/backend_api/session/jsonmodels/builders.py
@@ -78,16 +78,13 @@ class ObjectBuilder(Builder):
         if self.is_definition and not self.is_root:
             self.add_definition(builder)
             [self.maybe_build(value) for _, value in self.properties.items()]
-            return "#/definitions/{name}".format(name=self.type_name)
+            return f"#/definitions/{self.type_name}"
         else:
             return builder.build_definition(nullable=self.nullable)
 
     @property
     def type_name(self) -> str:
-        module_name = "{module}.{name}".format(
-            module=self.type.__module__,
-            name=self.type.__name__,
-        )
+        module_name = f"{self.type.__module__}.{self.type.__name__}"
         return module_name.replace(".", "_").lower()
 
     def build_definition(self, add_defintitions: bool = True, nullable: bool = False) -> dict:

--- a/clearml/backend_api/session/jsonmodels/parsers.py
+++ b/clearml/backend_api/session/jsonmodels/parsers.py
@@ -94,7 +94,7 @@ def _create_primitive_field_schema(
     elif isinstance(field, fields.BoolField):
         obj_type = "boolean"
     else:
-        raise errors.FieldNotSupported("Field {field} is not supported!".format(field=type(field).__class__.__name__))
+        raise errors.FieldNotSupported(f"Field {type(field).__class__.__name__} is not supported!")
 
     if field.nullable:
         obj_type = [obj_type, "null"]

--- a/clearml/backend_api/session/request.py
+++ b/clearml/backend_api/session/request.py
@@ -90,10 +90,17 @@ class BatchRequest(Request, ABC):
             try:
                 req.validate()
             except (SchemaError, ValidationError, FormatError, Unresolvable) as e:
-                raise Exception("Validation error in batch item #%d: %s" % (i, str(e)))
+                raise Exception(f"Validation error in batch item #{i}: {e}")
 
     def get_json(self) -> List[Union[Dict, Any]]:
-        return [r if isinstance(r, dict) else r.to_dict() for r in self.requests]
+        return [
+            (
+                r
+                if isinstance(r, dict)
+                else r.to_dict()
+            )
+            for r in self.requests
+        ]
 
 
 class CompoundRequest(Request):

--- a/clearml/backend_api/session/response.py
+++ b/clearml/backend_api/session/response.py
@@ -54,23 +54,22 @@ class ResponseMeta(jsonmodels.models.Base):
     error_stack = jsonmodels.fields.StringField()
 
     def __str__(self) -> str:
-        if self.result_code == requests.codes.ok:
-            return "<%d: %s/v%s>" % (
-                self.result_code,
-                self.endpoint.name,
-                self.endpoint.actual_version,
+        result_code = (
+            self.result_code
+            if self.result_code == requests.codes.ok
+            else f"{self.result_code}/{self.result_subcode}"
+        )
+        endpoint = (
+            f"{self.endpoint.name}/v{self.endpoint.actual_version}"
+            if (
+                self.result_code == requests.codes.ok
+                or self._is_valid
             )
-        elif self._is_valid:
-            return "<%d/%d: %s/v%s (%s)>" % (
-                self.result_code,
-                self.result_subcode,
-                self.endpoint.name,
-                self.endpoint.actual_version,
-                self.result_msg,
-            )
-        return "<%d/%d: %s (%s)>" % (
-            self.result_code,
-            self.result_subcode,
-            self.endpoint.name,
-            self.result_msg,
+            else self.endpoint.name
+        )
+
+        return (
+            f"<{result_code}: {endpoint} ({self.result_msg})>"
+            if self.result_msg
+            else f"<{result_code}: {endpoint}>"
         )


### PR DESCRIPTION
## Related Issue \ discussion
See issue #1547.

## Patch Description
This replaces .format and % formatting calls with `f`-strings in the `clearml/backend_api` folder.
