### PR TITLE
fix: normalize leading slashes in project names

### DIFF
--- a/clearml/backend_interface/util.py
+++ b/clearml/backend_interface/util.py
@@ -107,6 +107,7 @@ def _get_or_create_project(
     project_id: Optional[str] = None,
 ) -> Optional[str]:
     """Return the ID of an existing project, or if it does not exist, make a new one and return that ID instead."""
+    project_name = project_name.lstrip("/")
     project_system_tags = []
     if not project_id:
         res = session.send(

--- a/tests/test_backend_interface_util.py
+++ b/tests/test_backend_interface_util.py
@@ -1,0 +1,35 @@
+import re
+from types import SimpleNamespace
+
+from clearml.backend_interface.util import get_or_create_project
+
+
+class NormalizingProjectSession:
+    def __init__(self):
+        self.projects = {}
+
+    def send(self, request):
+        if request.__class__.__name__ == "GetAllRequest":
+            matches = [
+                SimpleNamespace(id=project_id, system_tags=[])
+                for name, project_id in self.projects.items()
+                if re.fullmatch(request.name, name)
+            ]
+            return SimpleNamespace(response=SimpleNamespace(projects=matches))
+        if request.__class__.__name__ == "CreateRequest":
+            normalized_name = request.name.lstrip("/")
+            if normalized_name in self.projects:
+                raise RuntimeError("Project with the same name already exists")
+            self.projects[normalized_name] = "project-id"
+            return SimpleNamespace(response=SimpleNamespace(id="project-id"))
+        raise AssertionError(type(request))
+
+
+def test_get_or_create_project_normalizes_leading_slashes():
+    session = NormalizingProjectSession()
+
+    first_id = get_or_create_project(session, "/tmp/test/runs")
+    second_id = get_or_create_project(session, "/tmp/test/runs")
+
+    assert first_id == second_id == "project-id"
+    assert session.projects == {"tmp/test/runs": "project-id"}


### PR DESCRIPTION
## Related Issue \ discussion

Fixes #1643

## Patch Description

Normalize leading separators before project lookup and creation, matching the server's stored project name so repeated `Task.init()` calls reuse the existing project

## Testing Instructions

`python -m pytest -q tests/test_backend_interface_util.py`

## Other Information

None
