### PR TITLE
gh-1547: clearml/backend_config - move .format -> f-string

### DIFF
--- a/clearml/backend_config/bucket_config.py
+++ b/clearml/backend_config/bucket_config.py
@@ -76,18 +76,33 @@ class S3BucketConfig:
         dict_list: Union[Tuple[Dict], List[Dict]],
         log: Optional[logging.Logger] = None,
     ) -> List["S3BucketConfig"]:
-        if not isinstance(dict_list, (tuple, list)) or not all(isinstance(x, dict) for x in dict_list):
-            raise ValueError("Expecting a list of configurations dictionaries")
-        configs = [cls(**entry) for entry in dict_list]
-        valid_configs = [conf for conf in configs if conf.is_valid()]
-        if log and len(valid_configs) < len(configs):
-            log.warning(
-                "Invalid bucket configurations detected for {}".format(
-                    ", ".join(
-                        "/".join((config.host, config.bucket)) for config in configs if config not in valid_configs
-                    )
-                )
+        if not (
+            isinstance(dict_list, (tuple, list))
+            and all(
+                isinstance(x, dict)
+                for x in dict_list
             )
+        ):
+            raise ValueError("Expecting a list of configurations dictionaries")
+
+        configs = [
+            cls(**entry)
+            for entry in dict_list
+        ]
+        valid_configs = [
+            conf
+            for conf in configs
+            if conf.is_valid()
+        ]
+
+        if log and len(valid_configs) < len(configs):
+            buckets_with_invalid_configuration = ", ".join((
+                f"{config.host}/{config.bucket}"
+                for config in configs
+                if config not in valid_configs
+            ))
+            log.warning(f"Invalid bucket configurations detected for {buckets_with_invalid_configuration}")
+
         return valid_configs
 
 
@@ -281,7 +296,7 @@ class GSBucketConfig:
     def update(self, **kwargs: Any) -> None:
         for item in kwargs:
             if not hasattr(self, item):
-                warnings.warn("Unexpected argument {} for update. Ignored".format(item))
+                warnings.warn(f"Unexpected argument {item} for update. Ignored")
             else:
                 setattr(self, item, kwargs[item])
 
@@ -388,7 +403,7 @@ class AzureContainerConfig:
     def update(self, **kwargs: Any) -> None:
         for item in kwargs:
             if not hasattr(self, item):
-                warnings.warn("Unexpected argument {} for update. Ignored".format(item))
+                warnings.warn(f"Unexpected argument {item} for update. Ignored")
             else:
                 setattr(self, item, kwargs[item])
 
@@ -460,8 +475,8 @@ class AzureContainerConfigurations:
 
         if not f.path.segments:
             raise ValueError(
-                "URI {} is missing a container name (expected "
-                "[https/azure]://<account-name>.../<container-name>)".format(uri)
+                f"URI {uri} is missing a container name (expected "
+                "[https/azure]://<account-name>.../<container-name>)"
             )
 
         container = f.path.segments[0]

--- a/clearml/backend_config/utils.py
+++ b/clearml/backend_config/utils.py
@@ -58,14 +58,14 @@ def apply_files(config: "Config") -> None:
         # noinspection PyBroadException
         try:
             if target.is_dir():
-                print("Skipped [{}]: is a directory {}".format(key, target))
+                print(f"Skipped [{key}]: is a directory {target}")
                 continue
 
             if not overwrite and target.is_file():
-                print("Skipped [{}]: file exists {}".format(key, target))
+                print(f"Skipped [{key}]: file exists {target}")
                 continue
         except Exception as ex:
-            print("Skipped [{}]: can't access {} ({})".format(key, target, ex))
+            print(f"Skipped [{key}]: can't access {target} ({ex})")
             continue
 
         if contents:
@@ -75,14 +75,14 @@ def apply_files(config: "Config") -> None:
                     if target_fmt != "bytes":
                         contents = contents.decode("utf-8")
             except Exception as ex:
-                print("Skipped [{}]: failed decoding {} ({})".format(key, fmt, ex))
+                print(f"Skipped [{key}]: failed decoding {fmt} ({ex})")
                 continue
 
         # noinspection PyBroadException
         try:
             target.parent.mkdir(parents=True, exist_ok=True)
         except Exception as ex:
-            print("Skipped [{}]: failed creating path {} ({})".format(key, target.parent, ex))
+            print(f"Skipped [{key}]: failed creating path {target.parent} ({ex})")
             continue
 
         try:
@@ -103,10 +103,10 @@ def apply_files(config: "Config") -> None:
                             contents = contents.as_plain_ordered_dict()
                         text = str(contents)
                 except Exception as ex:
-                    print("Skipped [{}]: failed encoding to {} ({})".format(key, target_fmt, ex))
+                    print(f"Skipped [{key}]: failed encoding to {target_fmt} ({ex})")
                     continue
                 target.write_text(text)
-            print("Saved [{}]: {}".format(key, target))
+            print(f"Saved [{key}]: {target}")
         except Exception as ex:
-            print("Skipped [{}]: failed saving file {} ({})".format(key, target, ex))
+            print(f"Skipped [{key}]: failed saving file {target} ({ex})")
             continue


### PR DESCRIPTION
## Related Issue \ discussion
See issue #1547 .

## Patch Description
This removes usage of `.format` in the `clearml/backend_config` folder, preferring `f`-string formatting instead.